### PR TITLE
`alfa-test-utils`: extract and send metadata to the Siteimprove Intelligence Platform

### DIFF
--- a/config/validate-structure.json
+++ b/config/validate-structure.json
@@ -29,7 +29,7 @@
       "@siteimprove/alfa-puppeteer": ["puppeteer"],
       "@siteimprove/alfa-react": ["react", "react-test-renderer"],
       "@siteimprove/alfa-scraper": ["puppeteer"],
-      "@siteimprove/alfa-test-utils": ["axios"],
+      "@siteimprove/alfa-test-utils": ["axios", "simple-git"],
       "@siteimprove/alfa-unexpected": ["unexpected"],
       "@siteimprove/alfa-vue": [
         "@vue/test-utils",

--- a/docs/review/api/alfa-test-utils.api.md
+++ b/docs/review/api/alfa-test-utils.api.md
@@ -4,10 +4,14 @@
 
 ```ts
 
+/// <reference types="node" />
+
+import type { Agent } from 'https';
 import { alfaVersion } from '@siteimprove/alfa-rules';
 import { Array as Array_2 } from '@siteimprove/alfa-array';
 import type { AxiosRequestConfig } from 'axios';
 import { Flattened } from '@siteimprove/alfa-rules';
+import { Map as Map_2 } from '@siteimprove/alfa-map';
 import { Node } from '@siteimprove/alfa-dom';
 import { Outcome } from '@siteimprove/alfa-act';
 import type { Page } from '@siteimprove/alfa-web';
@@ -21,8 +25,6 @@ export type alfaOutcome = Outcome<Flattened.Input, Flattened.Target, Flattened.Q
 
 // @public
 export namespace Audit {
-    // @internal
-    export function aggregates(outcomes: Sequence<alfaOutcome>): Iterable<RuleAggregate>;
     export interface Filter<T> {
         // (undocumented)
         exclude?: Predicate<T>;
@@ -41,20 +43,15 @@ export namespace Audit {
     export interface Result {
         alfaVersion: typeof alfaVersion;
         durations: Performance.Durations;
-        outcomes: Sequence<alfaOutcome>;
+        outcomes: Map_2<string, Sequence<alfaOutcome>>;
         page: Page;
-        resultAggregates: Iterable<RuleAggregate>;
+        resultAggregates: ResultAggregates;
     }
-    export interface RuleAggregate {
-        // (undocumented)
-        CantTell: number;
-        // (undocumented)
+    export type ResultAggregates = Map_2<string, {
         Failed: number;
-        // (undocumented)
         Passed: number;
-        // (undocumented)
-        RuleId: string;
-    }
+        CantTell: number;
+    }>;
     export function run(page: Page, options?: Options): Promise<Result>;
 }
 
@@ -140,8 +137,9 @@ export namespace SIP {
         export function axiosConfig(audit: Audit.Result, options: Options, override: {
             url?: string;
             timestamp?: string;
+            httpsAgent?: Agent;
         }): Promise<AxiosRequestConfig>;
-        export function params(url: string, apiKey: string): AxiosRequestConfig;
+        export function params(url: string, apiKey: string, httpsAgent?: Agent): AxiosRequestConfig;
         // (undocumented)
         export interface Payload {
             CheckDurations: Performance.Durations;
@@ -149,7 +147,12 @@ export namespace SIP {
             PageTitle: string;
             PageUrl: string;
             RequestTimestamp: string;
-            ResultAggregates: Array_2<Audit.RuleAggregate>;
+            ResultAggregates: Array_2<{
+                RuleId: string;
+                Failed: number;
+                Passed: number;
+                CantTell: number;
+            }>;
             TestName: string;
             Version: `${number}.${number}.${number}`;
         }
@@ -186,6 +189,7 @@ export namespace SIP {
     export function upload(audit: Audit.Result, options: Options, override: {
         url?: string;
         timestamp?: string;
+        httpsAgent?: Agent;
     }): Promise<string>;
 }
 

--- a/docs/review/api/alfa-test-utils.api.md
+++ b/docs/review/api/alfa-test-utils.api.md
@@ -17,6 +17,7 @@ import { Outcome } from '@siteimprove/alfa-act';
 import type { Page } from '@siteimprove/alfa-web';
 import { Performance as Performance_2 } from '@siteimprove/alfa-performance';
 import type { Predicate } from '@siteimprove/alfa-predicate';
+import type { Result } from '@siteimprove/alfa-result';
 import type { Rule } from '@siteimprove/alfa-act';
 import { Sequence } from '@siteimprove/alfa-sequence';
 
@@ -48,9 +49,9 @@ export namespace Audit {
         resultAggregates: ResultAggregates;
     }
     export type ResultAggregates = Map_2<string, {
-        Failed: number;
-        Passed: number;
-        CantTell: number;
+        failed: number;
+        passed: number;
+        cantTell: number;
     }>;
     export function run(page: Page, options?: Options): Promise<Result>;
 }
@@ -68,13 +69,15 @@ export namespace Outcomes {
 export namespace Performance {
     const // (undocumented)
     durationKeys: readonly ["applicability", "expectation", "total"];
+    // Warning: (ae-incompatible-release-tags) The symbol "CommonDurations" is marked as @public, but its signature references "Performance" which is marked as @internal
+    //
     // (undocumented)
     export type CommonDurations = {
         [K in CommonKeys]: number;
     };
-    // (undocumented)
+    // @internal (undocumented)
     export type CommonKeys = (typeof commonKeys)[number];
-    // (undocumented)
+    // @internal (undocumented)
     export type DurationKey = (typeof durationKeys)[number];
     export type Durations = {
         common: CommonDurations;
@@ -90,6 +93,8 @@ export namespace Performance {
     export function recordCommon(durations: Durations): Performance_2<string>;
     // @internal (undocumented)
     export function recordRule(durations: Durations): Performance_2<RuleEvent>;
+    // Warning: (ae-incompatible-release-tags) The symbol "RuleDurations" is marked as @public, but its signature references "Performance" which is marked as @internal
+    //
     // (undocumented)
     export type RuleDurations = {
         [K in DurationKey]: number;
@@ -139,11 +144,15 @@ export namespace SIP {
             timestamp?: string;
             httpsAgent?: Agent;
         }): Promise<AxiosRequestConfig>;
+        // (undocumented)
+        export type CommonDurations = {
+            [K in CamelCase<Performance.CommonKeys>]: number;
+        };
         export function params(url: string, apiKey: string, httpsAgent?: Agent): AxiosRequestConfig;
         // (undocumented)
         export interface Payload {
-            CheckDurations: Performance.Durations;
             CommitInformation?: CommitInformation;
+            Durations: CommonDurations;
             PageTitle: string;
             PageUrl: string;
             RequestTimestamp: string;
@@ -152,11 +161,19 @@ export namespace SIP {
                 Failed: number;
                 Passed: number;
                 CantTell: number;
+                Durations: RuleDurations;
             }>;
             TestName: string;
             Version: `${number}.${number}.${number}`;
         }
         export function payload(audit: Audit.Result, options: Partial<Options>, timestamp: string, defaultTitle?: string, defaultName?: string): Promise<Payload>;
+        // Warning: (ae-forgotten-export) The symbol "CamelCase" needs to be exported by the entry point index.d.ts
+        //
+        // (undocumented)
+        export type RuleDurations = {
+            [K in CamelCase<Performance.DurationKey>]: number;
+        };
+            {};
     }
     // (undocumented)
     export interface Options {
@@ -184,13 +201,13 @@ export namespace SIP {
         export function payload(Id: string, audit: Audit.Result): Payload;
             {};
     }
-    export function upload(audit: Audit.Result, options: Options): Promise<string>;
+    export function upload(audit: Audit.Result, options: Options): Promise<Result<string, string>>;
     // @internal
     export function upload(audit: Audit.Result, options: Options, override: {
         url?: string;
         timestamp?: string;
         httpsAgent?: Agent;
-    }): Promise<string>;
+    }): Promise<Result<string, string>>;
 }
 
 ```

--- a/docs/review/api/alfa-test-utils.api.md
+++ b/docs/review/api/alfa-test-utils.api.md
@@ -4,11 +4,13 @@
 
 ```ts
 
+import { alfaVersion } from '@siteimprove/alfa-rules';
+import { Array as Array_2 } from '@siteimprove/alfa-array';
 import type { AxiosRequestConfig } from 'axios';
-import type { Flattened } from '@siteimprove/alfa-rules';
+import { Flattened } from '@siteimprove/alfa-rules';
 import { Node } from '@siteimprove/alfa-dom';
 import { Outcome } from '@siteimprove/alfa-act';
-import { Page } from '@siteimprove/alfa-web';
+import type { Page } from '@siteimprove/alfa-web';
 import type { Predicate } from '@siteimprove/alfa-predicate';
 import { Sequence } from '@siteimprove/alfa-sequence';
 
@@ -17,6 +19,8 @@ export type alfaOutcome = Outcome<Flattened.Input, Flattened.Target, Flattened.Q
 
 // @public
 export namespace Audit {
+    // @internal
+    export function aggregates(outcomes: Sequence<alfaOutcome>): Iterable<RuleAggregate>;
     export interface Filter<T> {
         // (undocumented)
         exclude?: Predicate<T>;
@@ -33,8 +37,20 @@ export namespace Audit {
         };
     }
     export interface Result {
-        // (undocumented)
+        alfaVersion: typeof alfaVersion;
         outcomes: Sequence<alfaOutcome>;
+        page: Page;
+        ResultAggregates: Iterable<RuleAggregate>;
+    }
+    export interface RuleAggregate {
+        // (undocumented)
+        CantTell: number;
+        // (undocumented)
+        Failed: number;
+        // (undocumented)
+        Passed: number;
+        // (undocumented)
+        RuleId: string;
     }
     export function run(page: Page, options?: Options): Promise<Result>;
 }
@@ -80,35 +96,39 @@ export namespace SIP {
     }
     // @internal
     export namespace Metadata {
-        export function axiosConfig(page: Page, options: Options, override: {
+        export function axiosConfig(audit: Audit.Result, options: Options, override: {
             url?: string;
             timestamp?: number;
-        }, defaultTitle?: string, defaultName?: string): AxiosRequestConfig;
+        }): Promise<AxiosRequestConfig>;
         export function params(url: string, apiKey: string): AxiosRequestConfig;
         // (undocumented)
         export interface Payload {
+            // Warning: (ae-forgotten-export) The symbol "CommitInformation" needs to be exported by the entry point index.d.ts
+            CommitInformation?: CommitInformation;
             // (undocumented)
             PageTitle: string;
             // (undocumented)
             RequestTimeStampMilliseconds: number;
             // (undocumented)
-            TestName: string;
+            ResultAggregates: Array_2<Audit.RuleAggregate>;
             // (undocumented)
+            TestName: string;
             Version: `${number}.${number}.${number}`;
         }
-        export function payload(PageTitle: string, TestName: string, timestamp: number): Payload;
+        export function payload(audit: Audit.Result, options: Partial<Options>, timestamp: number, defaultTitle?: string, defaultName?: string): Promise<Payload>;
             {};
     }
     // (undocumented)
     export interface Options {
         apiKey: string;
+        includeGitInfo?: boolean;
         pageTitle?: string;
         testName?: string;
         userName: string;
     }
     // @internal
     export namespace S3 {
-        export function axiosConfig(id: string, url: string, page: Page, outcomes: Iterable<alfaOutcome>): AxiosRequestConfig;
+        export function axiosConfig(id: string, url: string, audit: Audit.Result): AxiosRequestConfig;
         export function params(url: string): AxiosRequestConfig;
         // (undocumented)
         export interface Payload {
@@ -119,12 +139,12 @@ export namespace SIP {
             // (undocumented)
             Id: string;
         }
-        export function payload(Id: string, page: Page, outcomes: Iterable<alfaOutcome>): Payload;
+        export function payload(Id: string, audit: Audit.Result): Payload;
             {};
     }
-    export function upload(page: Page, outcomes: Iterable<alfaOutcome>, options: Options): Promise<string>;
+    export function upload(audit: Audit.Result, options: Options): Promise<string>;
     // @internal
-    export function upload(page: Page, outcomes: Iterable<alfaOutcome>, options: Options, override: {
+    export function upload(audit: Audit.Result, options: Options, override: {
         url?: string;
         timestamp?: number;
     }): Promise<string>;

--- a/docs/review/api/alfa-test-utils.api.md
+++ b/docs/review/api/alfa-test-utils.api.md
@@ -11,7 +11,9 @@ import { Flattened } from '@siteimprove/alfa-rules';
 import { Node } from '@siteimprove/alfa-dom';
 import { Outcome } from '@siteimprove/alfa-act';
 import type { Page } from '@siteimprove/alfa-web';
+import { Performance as Performance_2 } from '@siteimprove/alfa-performance';
 import type { Predicate } from '@siteimprove/alfa-predicate';
+import type { Rule } from '@siteimprove/alfa-act';
 import { Sequence } from '@siteimprove/alfa-sequence';
 
 // @public
@@ -38,9 +40,10 @@ export namespace Audit {
     }
     export interface Result {
         alfaVersion: typeof alfaVersion;
+        durations: Performance.Durations;
         outcomes: Sequence<alfaOutcome>;
         page: Page;
-        ResultAggregates: Iterable<RuleAggregate>;
+        resultAggregates: Iterable<RuleAggregate>;
     }
     export interface RuleAggregate {
         // (undocumented)
@@ -62,6 +65,44 @@ export namespace Outcomes {
     const cantTellFilter: Predicate<alfaOutcome>;
     export function insideSelectorFilter(selector: string, traversal?: Node.Traversal): Predicate<alfaOutcome>;
     export function ruleAndSelectorFilter(ruleId: number, selector: string): Predicate<alfaOutcome>;
+}
+
+// @public
+export namespace Performance {
+    const // (undocumented)
+    durationKeys: readonly ["applicability", "expectation", "total"];
+    // (undocumented)
+    export type CommonDurations = {
+        [K in CommonKeys]: number;
+    };
+    // (undocumented)
+    export type CommonKeys = (typeof commonKeys)[number];
+    // (undocumented)
+    export type DurationKey = (typeof durationKeys)[number];
+    export type Durations = {
+        common: CommonDurations;
+        rules: RulesDurations;
+    };
+    const // (undocumented)
+    commonKeys: readonly ["cascade", "aria-tree", "total"];
+    // @internal (undocumented)
+    export function empty(): Durations;
+    // @internal (undocumented)
+    export function emptyRuleDurations(): RuleDurations;
+    // @internal (undocumented)
+    export function recordCommon(durations: Durations): Performance_2<string>;
+    // @internal (undocumented)
+    export function recordRule(durations: Durations): Performance_2<RuleEvent>;
+    // (undocumented)
+    export type RuleDurations = {
+        [K in DurationKey]: number;
+    };
+    // @internal (undocumented)
+    export type RuleEvent = Rule.Event<Flattened.Input, Flattened.Target, Flattened.Question, Flattened.Subject>;
+    export type RulesDurations = {
+        [key: string]: RuleDurations;
+    };
+        {};
 }
 
 // @public
@@ -98,32 +139,30 @@ export namespace SIP {
     export namespace Metadata {
         export function axiosConfig(audit: Audit.Result, options: Options, override: {
             url?: string;
-            timestamp?: number;
+            timestamp?: string;
         }): Promise<AxiosRequestConfig>;
         export function params(url: string, apiKey: string): AxiosRequestConfig;
         // (undocumented)
         export interface Payload {
-            // Warning: (ae-forgotten-export) The symbol "CommitInformation" needs to be exported by the entry point index.d.ts
+            CheckDurations: Performance.Durations;
             CommitInformation?: CommitInformation;
-            // (undocumented)
             PageTitle: string;
-            // (undocumented)
-            RequestTimeStampMilliseconds: number;
-            // (undocumented)
+            PageUrl: string;
+            RequestTimestamp: string;
             ResultAggregates: Array_2<Audit.RuleAggregate>;
-            // (undocumented)
             TestName: string;
             Version: `${number}.${number}.${number}`;
         }
-        export function payload(audit: Audit.Result, options: Partial<Options>, timestamp: number, defaultTitle?: string, defaultName?: string): Promise<Payload>;
-            {};
+        export function payload(audit: Audit.Result, options: Partial<Options>, timestamp: string, defaultTitle?: string, defaultName?: string): Promise<Payload>;
     }
     // (undocumented)
     export interface Options {
         apiKey: string;
         includeGitInfo?: boolean;
-        pageTitle?: string;
-        testName?: string;
+        pageTitle?: string | ((page: Page) => string);
+        pageURL?: string | ((page: Page) => string);
+        // Warning: (ae-forgotten-export) The symbol "CommitInformation" needs to be exported by the entry point index.d.ts
+        testName?: string | ((git: CommitInformation) => string);
         userName: string;
     }
     // @internal
@@ -146,7 +185,7 @@ export namespace SIP {
     // @internal
     export function upload(audit: Audit.Result, options: Options, override: {
         url?: string;
-        timestamp?: number;
+        timestamp?: string;
     }): Promise<string>;
 }
 

--- a/packages/alfa-test-utils/README.md
+++ b/packages/alfa-test-utils/README.md
@@ -1,0 +1,31 @@
+# alfa-test-utils
+
+Utilities for running Alfa locally and uploading results to the Siteimprove Intelligence Platform.
+
+## Installation
+
+Alfa is distributed as npm packages in the Github registry. See [Github documentation on the npm registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#installing-a-package) for configuring your package manager to use the Github registry for the `@siteimprove` organisation.
+
+```bash
+$ npm install --save-dev @siteimprove/alfa-test-utils
+```
+or
+```bash
+$ yarn add --dev @siteimprove/alfa-test-utils
+```
+
+## Basic usage
+
+Use scraper packages such as `@siteimprove/alfa-playwright` to grab a page, then a simple test script could look like this:
+
+```typescript
+import { Audit, Rules, SIP } from "@siteimprove/alfa-test-utils";
+
+Audit.run(page, { rules: { include: Rules.aaFilter } }).then((outcomes) => {
+  SIP.upload(outcomes, {
+    userName: process.env.SI_USERNAME,
+    apiKey: prcoess.env.SI_API_KEY,
+    testName: "WCAG 2.2 AA conformance test",
+  }).then(console.log);
+});
+```

--- a/packages/alfa-test-utils/README.md
+++ b/packages/alfa-test-utils/README.md
@@ -24,7 +24,7 @@ import { Audit, Rules, SIP } from "@siteimprove/alfa-test-utils";
 Audit.run(page, { rules: { include: Rules.aaFilter } }).then((outcomes) => {
   SIP.upload(outcomes, {
     userName: process.env.SI_USERNAME,
-    apiKey: prcoess.env.SI_API_KEY,
+    apiKey: process.env.SI_API_KEY,
     testName: "WCAG 2.2 AA conformance test",
   }).then(console.log);
 });

--- a/packages/alfa-test-utils/package.json
+++ b/packages/alfa-test-utils/package.json
@@ -34,6 +34,7 @@
     "@siteimprove/alfa-dom": "^0.88.0",
     "@siteimprove/alfa-iterable": "^0.88.0",
     "@siteimprove/alfa-json": "^0.88.0",
+    "@siteimprove/alfa-map": "^0.88.0",
     "@siteimprove/alfa-performance": "^0.88.0",
     "@siteimprove/alfa-predicate": "^0.88.0",
     "@siteimprove/alfa-refinement": "^0.88.0",

--- a/packages/alfa-test-utils/package.json
+++ b/packages/alfa-test-utils/package.json
@@ -52,6 +52,7 @@
     "@siteimprove/alfa-record": "^0.88.0",
     "@siteimprove/alfa-result": "^0.88.0",
     "@siteimprove/alfa-test": "^0.88.0",
+    "@siteimprove/alfa-url": "^0.88.0",
     "axios-mock-adapter": "^1.22.0"
   }
 }

--- a/packages/alfa-test-utils/package.json
+++ b/packages/alfa-test-utils/package.json
@@ -32,6 +32,7 @@
     "@siteimprove/alfa-dom": "^0.88.0",
     "@siteimprove/alfa-iterable": "^0.88.0",
     "@siteimprove/alfa-json": "^0.88.0",
+    "@siteimprove/alfa-performance": "^0.88.0",
     "@siteimprove/alfa-predicate": "^0.88.0",
     "@siteimprove/alfa-refinement": "^0.88.0",
     "@siteimprove/alfa-rules": "^0.88.0",

--- a/packages/alfa-test-utils/package.json
+++ b/packages/alfa-test-utils/package.json
@@ -27,7 +27,9 @@
   },
   "dependencies": {
     "@siteimprove/alfa-act": "^0.88.0",
+    "@siteimprove/alfa-aria": "^0.88.0",
     "@siteimprove/alfa-array": "^0.88.0",
+    "@siteimprove/alfa-cascade": "^0.88.0",
     "@siteimprove/alfa-css": "^0.88.0",
     "@siteimprove/alfa-dom": "^0.88.0",
     "@siteimprove/alfa-iterable": "^0.88.0",

--- a/packages/alfa-test-utils/package.json
+++ b/packages/alfa-test-utils/package.json
@@ -39,7 +39,8 @@
     "@siteimprove/alfa-sequence": "^0.88.0",
     "@siteimprove/alfa-wcag": "^0.88.0",
     "@siteimprove/alfa-web": "^0.88.0",
-    "axios": "^1.7.2"
+    "axios": "^1.7.2",
+    "simple-git": "^3.25.0"
   },
   "devDependencies": {
     "@siteimprove/alfa-device": "^0.88.0",

--- a/packages/alfa-test-utils/package.json
+++ b/packages/alfa-test-utils/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@siteimprove/alfa-act": "^0.88.0",
+    "@siteimprove/alfa-array": "^0.88.0",
     "@siteimprove/alfa-css": "^0.88.0",
     "@siteimprove/alfa-dom": "^0.88.0",
     "@siteimprove/alfa-iterable": "^0.88.0",

--- a/packages/alfa-test-utils/src/audit/audit.ts
+++ b/packages/alfa-test-utils/src/audit/audit.ts
@@ -58,7 +58,7 @@ export namespace Audit {
    */
   export type ResultAggregates = Map<
     string,
-    { Failed: number; Passed: number; CantTell: number }
+    { failed: number; passed: number; cantTell: number }
   >;
 
   /**
@@ -97,9 +97,9 @@ export namespace Audit {
       .map((ruleOutcomes) => ruleOutcomes.groupBy((outcome) => outcome.outcome))
       // Count the size of each group and build the aggregates
       .map((groups, uri) => ({
-        Failed: groups.get(Outcome.Value.Failed).getOrElse(Sequence.empty).size,
-        Passed: groups.get(Outcome.Value.Passed).getOrElse(Sequence.empty).size,
-        CantTell: groups.get(Outcome.Value.CantTell).getOrElse(Sequence.empty)
+        failed: groups.get(Outcome.Value.Failed).getOrElse(Sequence.empty).size,
+        passed: groups.get(Outcome.Value.Passed).getOrElse(Sequence.empty).size,
+        cantTell: groups.get(Outcome.Value.CantTell).getOrElse(Sequence.empty)
           .size,
       }));
 

--- a/packages/alfa-test-utils/src/audit/audit.ts
+++ b/packages/alfa-test-utils/src/audit/audit.ts
@@ -18,6 +18,7 @@ export namespace Audit {
    * The result of an audit.
    */
   export interface Result {
+    page: Page;
     outcomes: Sequence<alfaOutcome>;
   }
 
@@ -40,7 +41,7 @@ export namespace Audit {
       await alfaAudit.of(page, rulesToRun).evaluate()
     );
 
-    return { outcomes: filter(outcomes, options.outcomes) };
+    return { page, outcomes: filter(outcomes, options.outcomes) };
   }
 
   /**

--- a/packages/alfa-test-utils/src/audit/audit.ts
+++ b/packages/alfa-test-utils/src/audit/audit.ts
@@ -71,12 +71,13 @@ export namespace Audit {
     const outcomes = Sequence.from(
       await alfaAudit.of(page, rulesToRun).evaluate()
     );
+    const ResultAggregates = aggregates(outcomes);
 
     return {
       alfaVersion,
       page,
       outcomes: filter(outcomes, options.outcomes),
-      ResultAggregates: aggregates(outcomes),
+      ResultAggregates,
     };
   }
 

--- a/packages/alfa-test-utils/src/audit/audit.ts
+++ b/packages/alfa-test-utils/src/audit/audit.ts
@@ -75,13 +75,7 @@ export namespace Audit {
     const rulesPerformance = Performance.recordRule(durations);
 
     const start = commonPerformance.mark("total").start;
-    const startCascade = commonPerformance.mark("cascade").start;
-    Cascade.from(page.document, page.device);
-    commonPerformance.measure("cascade", startCascade);
-
-    const startAria = commonPerformance.mark("aria-tree").start;
-    ariaNode.from(page.document, page.device);
-    commonPerformance.measure("aria-tree", startAria);
+    sharedPerformance(commonPerformance, page);
 
     const rulesToRun =
       options.rules?.override ?? false
@@ -185,5 +179,25 @@ export namespace Audit {
      * Filter outcomes to show.
      */
     outcomes?: Filter<alfaOutcome>;
+  }
+
+  /**
+   * Resolve Cascade and build the ARIA tree, while recording performance.
+   *
+   * @remarks
+   * This ensures that these costly but cached operations are "charged" separately
+   * and not unfairly on the first rule using them.
+   */
+  function sharedPerformance(
+    performance: alfaPerformance<string>,
+    page: Page
+  ): void {
+    const startCascade = performance.mark("cascade").start;
+    Cascade.from(page.document, page.device);
+    performance.measure("cascade", startCascade);
+
+    const startAria = performance.mark("aria-tree").start;
+    ariaNode.from(page.document, page.device);
+    performance.measure("aria-tree", startAria);
   }
 }

--- a/packages/alfa-test-utils/src/audit/audit.ts
+++ b/packages/alfa-test-utils/src/audit/audit.ts
@@ -1,6 +1,6 @@
 import { Audit as alfaAudit } from "@siteimprove/alfa-act";
 import type { Predicate } from "@siteimprove/alfa-predicate";
-import type { Flattened } from "@siteimprove/alfa-rules";
+import { alfaVersion, type Flattened } from "@siteimprove/alfa-rules";
 import { Sequence } from "@siteimprove/alfa-sequence";
 import type { Page } from "@siteimprove/alfa-web";
 
@@ -18,6 +18,7 @@ export namespace Audit {
    * The result of an audit.
    */
   export interface Result {
+    alfaVersion: typeof alfaVersion;
     page: Page;
     outcomes: Sequence<alfaOutcome>;
   }
@@ -41,7 +42,7 @@ export namespace Audit {
       await alfaAudit.of(page, rulesToRun).evaluate()
     );
 
-    return { page, outcomes: filter(outcomes, options.outcomes) };
+    return { alfaVersion, page, outcomes: filter(outcomes, options.outcomes) };
   }
 
   /**

--- a/packages/alfa-test-utils/src/audit/index.ts
+++ b/packages/alfa-test-utils/src/audit/index.ts
@@ -1,3 +1,4 @@
 export * from "./audit.js";
 export * from "./outcomes.js";
+export * from "./performance.js";
 export * from "./rules.js";

--- a/packages/alfa-test-utils/src/audit/performance.ts
+++ b/packages/alfa-test-utils/src/audit/performance.ts
@@ -1,0 +1,68 @@
+import type { Rule } from "@siteimprove/alfa-act";
+import { Performance } from "@siteimprove/alfa-performance";
+import type { Flattened } from "@siteimprove/alfa-rules";
+
+const { isMeasure } = Performance.Measure;
+
+/**
+ * Records the duration of resolving the CSS cascade, building the accessibility
+ * tree, and running each rule.
+ *
+ * @remarks
+ * The cascade and accessibility tree are cached, so we store their performance
+ * separately to avoid unfairly "charging" the first rule to use and build them.
+ *
+ * @public
+ */
+export type Durations = {
+  common: { [key: string]: number };
+  rules: RuleDurations;
+};
+
+/**
+ * For each rule (key), records time taken for `applicability` and
+ * `expectation`.
+ *
+ * @public
+ */
+export type RuleDurations = {
+  [key: string]: { [key: string]: number };
+};
+
+/**
+ * @internal
+ */
+export type RuleEvent = Rule.Event<
+  Flattened.Input,
+  Flattened.Target,
+  Flattened.Question,
+  Flattened.Subject
+>;
+
+/**
+ * @internal
+ */
+export function recordRule(
+  ruleId: string,
+  durations: Durations,
+  entry: Performance.Entry<RuleEvent>
+): void {
+  if (isMeasure(entry)) {
+    if (durations.rules[ruleId] === undefined) {
+      durations.rules[ruleId] = {};
+    }
+    durations.rules[ruleId][entry.data.name] = entry.duration;
+  }
+}
+
+/**
+ * @internal
+ */
+export function recordCommon(
+  durations: Durations,
+  entry: Performance.Entry<string>
+): void {
+  if (isMeasure(entry)) {
+    durations.common[entry.data] = entry.duration;
+  }
+}

--- a/packages/alfa-test-utils/src/audit/performance.ts
+++ b/packages/alfa-test-utils/src/audit/performance.ts
@@ -13,7 +13,8 @@ const { isMeasure } = alfaPerformance.Measure;
 export namespace Performance {
   const durationKeys = ["applicability", "expectation", "total"] as const;
   type DurationKey = (typeof durationKeys)[number];
-  type RuleDurations = { [K in DurationKey]: number };
+  /** @internal */
+  export type RuleDurations = { [K in DurationKey]: number };
 
   /**
    * For each rule (key), records time taken for the applicability,
@@ -23,9 +24,7 @@ export namespace Performance {
    */
   export type RulesDurations = { [key: string]: RuleDurations };
 
-  /**
-   * @internal
-   */
+  /** @internal */
   export function emptyRuleDurations(): RuleDurations {
     return { applicability: 0, expectation: 0, total: 0 };
   }
@@ -46,9 +45,7 @@ export namespace Performance {
    */
   export type Durations = { common: CommonDurations; rules: RulesDurations };
 
-  /**
-   * @internal
-   */
+  /** @internal */
   export function empty(): Durations {
     return {
       common: { cascade: 0, "aria-tree": 0, total: 0 },
@@ -56,9 +53,7 @@ export namespace Performance {
     };
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   export type RuleEvent = Rule.Event<
     Flattened.Input,
     Flattened.Target,
@@ -66,9 +61,7 @@ export namespace Performance {
     Flattened.Subject
   >;
 
-  /**
-   * @internal
-   */
+  /** @internal */
   export function recordRule(durations: Durations): alfaPerformance<RuleEvent> {
     return alfaPerformance.of<Performance.RuleEvent>().on((entry) => {
       if (isMeasure(entry)) {
@@ -86,9 +79,7 @@ export namespace Performance {
     });
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   export function recordCommon(durations: Durations): alfaPerformance<string> {
     return alfaPerformance.of<string>().on((entry) => {
       if (isMeasure(entry) && Array.includes(commonKeys, entry.data)) {

--- a/packages/alfa-test-utils/src/audit/performance.ts
+++ b/packages/alfa-test-utils/src/audit/performance.ts
@@ -71,9 +71,9 @@ export namespace Performance {
    */
   export function recordRule(durations: Durations): alfaPerformance<RuleEvent> {
     return alfaPerformance.of<Performance.RuleEvent>().on((entry) => {
-      const ruleId = entry.data.rule.uri;
-
       if (isMeasure(entry)) {
+        const ruleId = entry.data.rule.uri;
+
         if (durations.rules[ruleId] === undefined) {
           durations.rules[ruleId] = emptyRuleDurations();
         }

--- a/packages/alfa-test-utils/src/audit/performance.ts
+++ b/packages/alfa-test-utils/src/audit/performance.ts
@@ -12,9 +12,9 @@ const { isMeasure } = alfaPerformance.Measure;
  */
 export namespace Performance {
   const durationKeys = ["applicability", "expectation", "total"] as const;
-  type DurationKey = (typeof durationKeys)[number];
   /** @internal */
-  export type RuleDurations = { [K in DurationKey]: number };
+  export type DurationKey = (typeof durationKeys)[number];
+  type RuleDurations = { [K in DurationKey]: number };
 
   /**
    * For each rule (key), records time taken for the applicability,
@@ -30,7 +30,8 @@ export namespace Performance {
   }
 
   const commonKeys = ["cascade", "aria-tree", "total"] as const;
-  type CommonKeys = (typeof commonKeys)[number];
+  /** @internal */
+  export type CommonKeys = (typeof commonKeys)[number];
   type CommonDurations = { [K in CommonKeys]: number };
 
   /**

--- a/packages/alfa-test-utils/src/audit/performance.ts
+++ b/packages/alfa-test-utils/src/audit/performance.ts
@@ -1,68 +1,100 @@
 import type { Rule } from "@siteimprove/alfa-act";
-import { Performance } from "@siteimprove/alfa-performance";
+import { Array } from "@siteimprove/alfa-array";
+import { Performance as alfaPerformance } from "@siteimprove/alfa-performance";
 import type { Flattened } from "@siteimprove/alfa-rules";
 
-const { isMeasure } = Performance.Measure;
+const { isMeasure } = alfaPerformance.Measure;
 
 /**
- * Records the duration of resolving the CSS cascade, building the accessibility
- * tree, and running each rule.
- *
- * @remarks
- * The cascade and accessibility tree are cached, so we store their performance
- * separately to avoid unfairly "charging" the first rule to use and build them.
+ * Record various durations in an audit.
  *
  * @public
  */
-export type Durations = {
-  common: { [key: string]: number };
-  rules: RuleDurations;
-};
+export namespace Performance {
+  const durationKeys = ["applicability", "expectation", "total"] as const;
+  type DurationKey = (typeof durationKeys)[number];
+  type RuleDurations = { [K in DurationKey]: number };
 
-/**
- * For each rule (key), records time taken for `applicability` and
- * `expectation`.
- *
- * @public
- */
-export type RuleDurations = {
-  [key: string]: { [key: string]: number };
-};
+  /**
+   * For each rule (key), records time taken for the applicability,
+   * the expectations, and total time.
+   *
+   * @public
+   */
+  export type RulesDurations = { [key: string]: RuleDurations };
 
-/**
- * @internal
- */
-export type RuleEvent = Rule.Event<
-  Flattened.Input,
-  Flattened.Target,
-  Flattened.Question,
-  Flattened.Subject
->;
-
-/**
- * @internal
- */
-export function recordRule(
-  ruleId: string,
-  durations: Durations,
-  entry: Performance.Entry<RuleEvent>
-): void {
-  if (isMeasure(entry)) {
-    if (durations.rules[ruleId] === undefined) {
-      durations.rules[ruleId] = {};
-    }
-    durations.rules[ruleId][entry.data.name] = entry.duration;
+  /**
+   * @internal
+   */
+  export function emptyRuleDurations(): RuleDurations {
+    return { applicability: 0, expectation: 0, total: 0 };
   }
-}
 
-/**
- * @internal
- */
-export function recordCommon(
-  durations: Durations,
-  entry: Performance.Entry<string>
-): void {
-  if (isMeasure(entry)) {
-    durations.common[entry.data] = entry.duration;
+  const commonKeys = ["cascade", "aria-tree", "total"] as const;
+  type CommonKeys = (typeof commonKeys)[number];
+  type CommonDurations = { [K in CommonKeys]: number };
+
+  /**
+   * Records the duration of resolving the CSS cascade, building the accessibility
+   * tree, and running each rule.
+   *
+   * @remarks
+   * The cascade and accessibility tree are cached, so we store their performance
+   * separately to avoid unfairly "charging" the first rule to use and build them.
+   *
+   * @public
+   */
+  export type Durations = { common: CommonDurations; rules: RulesDurations };
+
+  /**
+   * @internal
+   */
+  export function empty(): Durations {
+    return {
+      common: { cascade: 0, "aria-tree": 0, total: 0 },
+      rules: {},
+    };
+  }
+
+  /**
+   * @internal
+   */
+  export type RuleEvent = Rule.Event<
+    Flattened.Input,
+    Flattened.Target,
+    Flattened.Question,
+    Flattened.Subject
+  >;
+
+  /**
+   * @internal
+   */
+  export function recordRule(durations: Durations): alfaPerformance<RuleEvent> {
+    return alfaPerformance.of<Performance.RuleEvent>().on((entry) => {
+      const ruleId = entry.data.rule.uri;
+
+      if (isMeasure(entry)) {
+        if (durations.rules[ruleId] === undefined) {
+          durations.rules[ruleId] = emptyRuleDurations();
+        }
+        if (Array.includes(durationKeys, entry.data.name)) {
+          // Type is ensured by the previous test.
+          durations.rules[ruleId][entry.data.name as DurationKey] =
+            entry.duration;
+        }
+      }
+    });
+  }
+
+  /**
+   * @internal
+   */
+  export function recordCommon(durations: Durations): alfaPerformance<string> {
+    return alfaPerformance.of<string>().on((entry) => {
+      if (isMeasure(entry) && Array.includes(commonKeys, entry.data)) {
+        // Type is ensured by the previous check
+        durations.common[entry.data as CommonKeys] = entry.duration;
+      }
+    });
   }
 }

--- a/packages/alfa-test-utils/src/report/git.ts
+++ b/packages/alfa-test-utils/src/report/git.ts
@@ -40,8 +40,8 @@ export async function getCommitInformation(): Promise<
   } catch (err) {
     return Err.of(
       err instanceof Error
-        ? err?.message ?? "Could not retrieve git information"
-        : String(err)
+        ? err.message
+        : "Could not retrieve git information: " + String(err)
     );
   }
 }

--- a/packages/alfa-test-utils/src/report/git.ts
+++ b/packages/alfa-test-utils/src/report/git.ts
@@ -9,7 +9,7 @@ const git = simpleGit();
  */
 export interface CommitInformation {
   GitOrigin: string | undefined;
-  Branch: string;
+  BranchName: string;
   CommitHash: string | undefined;
   Author: string | undefined;
   Email: string | undefined;
@@ -29,7 +29,7 @@ export async function getCommitInformation(): Promise<
 
     const value: CommitInformation = {
       GitOrigin: origin?.refs?.fetch,
-      Branch: branch.current,
+      BranchName: branch.current,
       CommitHash: latest?.latest?.hash,
       Author: latest?.latest?.author_name,
       Email: latest?.latest?.author_email,

--- a/packages/alfa-test-utils/src/report/git.ts
+++ b/packages/alfa-test-utils/src/report/git.ts
@@ -1,0 +1,47 @@
+import { Err, Ok } from "@siteimprove/alfa-result";
+import type { Result } from "@siteimprove/alfa-result";
+import { simpleGit } from "simple-git";
+
+const git = simpleGit();
+
+/**
+ * @public
+ */
+export interface CommitInformation {
+  GitOrigin: string | undefined;
+  Branch: string;
+  CommitHash: string | undefined;
+  Author: string | undefined;
+  Email: string | undefined;
+  CommitTimestamp: string | undefined;
+  Message: string | undefined;
+}
+
+export async function getCommitInformation(): Promise<
+  Result<CommitInformation, string>
+> {
+  try {
+    const origin = await git
+      .getRemotes(true)
+      .then((remotes) => remotes.find((remote) => remote.name === "origin"));
+    const branch = await git.branchLocal();
+    const latest = await git.log({ "--max-count": 1 });
+
+    const value: CommitInformation = {
+      GitOrigin: origin?.refs?.fetch,
+      Branch: branch.current,
+      CommitHash: latest?.latest?.hash,
+      Author: latest?.latest?.author_name,
+      Email: latest?.latest?.author_email,
+      CommitTimestamp: latest?.latest?.date,
+      Message: latest?.latest?.message,
+    };
+    return Ok.of(value);
+  } catch (err) {
+    return Err.of(
+      err instanceof Error
+        ? err?.message ?? "Could not retrieve git information"
+        : String(err)
+    );
+  }
+}

--- a/packages/alfa-test-utils/src/report/sip.ts
+++ b/packages/alfa-test-utils/src/report/sip.ts
@@ -137,6 +137,7 @@ export namespace SIP {
        * The time the request is sent, formatted as an ISO 8601 string.
        */
       RequestTimestamp: string;
+
       /**
        * Version of Alfa used for the checks
        */
@@ -161,8 +162,8 @@ export namespace SIP {
       // BackLink?: string;
 
       /**
-       * The URL of the page. Defaults to the URL but can be overwritten to
-       * avoid `localhost` addresses in local tests, …
+       * The URL of the page. Defaults to the URL in the Response but can be
+       * overwritten to avoid `localhost` addresses in local tests, …
        */
       PageUrl: string;
 
@@ -175,6 +176,7 @@ export namespace SIP {
       /**
        * Name of the test, e.g. "AA conformance", "Color contrast",
        * "On branch: \<branch name\>", …
+       * Defaults to "Accessibility Code Checker".
        */
       TestName: string;
 
@@ -195,7 +197,7 @@ export namespace SIP {
      * Prepare payload with metadata for creating pre-signed URL.
      *
      * @remarks
-     * The timestamp must be formated as an ISO 8601 formatted string.
+     * The timestamp must be formated as an ISO 8601 string.
      */
     export async function payload(
       audit: Audit.Result,
@@ -216,10 +218,7 @@ export namespace SIP {
           .getOr(defaultTitle);
       const PageTitle = typeof title === "string" ? title : title(audit.page);
 
-      const gitInfo =
-        options.includeGitInfo ?? true
-          ? await getCommitInformation()
-          : Err.of("Skip git information as per configuration options");
+      const gitInfo = await getCommitInformation();
 
       const name = options.testName ?? defaultName;
       const TestName =
@@ -239,8 +238,8 @@ export namespace SIP {
         CheckDurations: audit.durations,
       };
 
-      for (const git of gitInfo) {
-        result.CommitInformation = git;
+      if ((options.includeGitInfo ?? true) && gitInfo.isOk()) {
+        result.CommitInformation = gitInfo.get();
       }
 
       return result;

--- a/packages/alfa-test-utils/src/report/sip.ts
+++ b/packages/alfa-test-utils/src/report/sip.ts
@@ -131,20 +131,20 @@ export namespace SIP {
       PageUrl?: string;
 
       // Use git library to read this.
-      CommitInformation?: {
-        CommitHash: string;
-        GitOrigin: string;
-        Author: string;
-        Email: string;
-        CommitTimestamp: number;
-        Message: string;
-      };
+      // CommitInformation?: {
+      //   CommitHash: string;
+      //   GitOrigin: string;
+      //   Author: string;
+      //   Email: string;
+      //   CommitTimestamp: number;
+      //   Message: string;
+      // };
 
       ResultAggregates: Array<Audit.RuleAggregate>;
 
       // Is this the only performance info we want, or do we want the same breakdown
       // that dory gets? (https://github.com/Siteimprove/dory/blob/main/packages/dory-audit/src/performance.ts)
-      CheckDuration: number;
+      // CheckDuration: number;
     }
 
     /**
@@ -173,7 +173,7 @@ export namespace SIP {
         PageTitle: title,
         TestName: name,
         ResultAggregates: Array.from(audit.ResultAggregates),
-      } as unknown as Payload;
+      };
     }
 
     /**

--- a/packages/alfa-test-utils/src/report/sip.ts
+++ b/packages/alfa-test-utils/src/report/sip.ts
@@ -19,9 +19,7 @@ const { Verbosity } = Serializable;
  * @public
  */
 export namespace SIP {
-  /**
-   * @internal
-   */
+  /** @internal */
   export namespace Defaults {
     export const URL =
       "https://api.siteimprove.com/v2/a11y/AlfaDevCheck/CreateReport";
@@ -65,9 +63,7 @@ export namespace SIP {
       const axiosResponse = await axios.request(config);
       const { pageReportUrl, preSignedUrl, id } = axiosResponse.data;
 
-      const response = await axios.request(
-        S3.axiosConfig(id, preSignedUrl, audit)
-      );
+      await axios.request(S3.axiosConfig(id, preSignedUrl, audit));
 
       return pageReportUrl;
     } catch (error) {
@@ -130,9 +126,7 @@ export namespace SIP {
    * @internal
    */
   export namespace Metadata {
-    /**
-     * @internal
-     */
+    /** @internal */
     export interface Payload {
       /**
        * The time the request is sent, formatted as an ISO 8601 string.
@@ -190,13 +184,14 @@ export namespace SIP {
         Failed: number;
         Passed: number;
         CantTell: number;
+        // Durations: Performance.RuleDurations
       }>;
 
       /**
        * Performances of the audit, with durations per rules and some common
        * durations.
        */
-      CheckDurations: Performance.Durations;
+      Durations: Performance.Durations; // only common, CamelCase
     }
 
     /**
@@ -243,7 +238,7 @@ export namespace SIP {
         ResultAggregates: audit.resultAggregates
           .toArray()
           .map(([RuleId, data]) => ({ RuleId, ...data })),
-        CheckDurations: audit.durations,
+        Durations: audit.durations,
       };
 
       if ((options.includeGitInfo ?? true) && gitInfo.isOk()) {

--- a/packages/alfa-test-utils/src/report/sip.ts
+++ b/packages/alfa-test-utils/src/report/sip.ts
@@ -161,16 +161,16 @@ export namespace SIP {
       // BackLink?: string;
 
       /**
-       * The title of the page checked, defaults to the first `<title>` element
-       * if any, or "Unnamed page" if none.
-       */
-      PageTitle: string;
-
-      /**
        * The URL of the page. Defaults to the URL but can be overwritten to
        * avoid `localhost` addresses in local tests, …
        */
       PageUrl: string;
+
+      /**
+       * The title of the page checked, defaults to the first `<title>` element
+       * if any, or "Unnamed page" if none.
+       */
+      PageTitle: string;
 
       /**
        * Name of the test, e.g. "AA conformance", "Color contrast",

--- a/packages/alfa-test-utils/src/report/sip.ts
+++ b/packages/alfa-test-utils/src/report/sip.ts
@@ -1,13 +1,11 @@
 import { Element, Query } from "@siteimprove/alfa-dom";
 import { Serializable } from "@siteimprove/alfa-json";
-import { alfaVersion } from "@siteimprove/alfa-rules";
 import { Sequence } from "@siteimprove/alfa-sequence";
 import { Page } from "@siteimprove/alfa-web";
 
 import type { AxiosRequestConfig } from "axios";
 import axios from "axios";
 
-import type { alfaOutcome } from "../common.js";
 import type { Audit } from "../audit/audit.js";
 
 const { Verbosity } = Serializable;
@@ -57,7 +55,12 @@ export namespace SIP {
     options: Options,
     override: { url?: string; timestamp?: number } = {}
   ): Promise<string> {
-    const config = Metadata.axiosConfig(audit.page, options, override);
+    const config = Metadata.axiosConfig(
+      audit.alfaVersion,
+      audit.page,
+      options,
+      override
+    );
 
     try {
       const axiosResponse = await axios.request(config);
@@ -113,15 +116,61 @@ export namespace SIP {
   export namespace Metadata {
     interface Payload {
       RequestTimeStampMilliseconds: number;
+      /**
+       * Version of Alfa used for the checks
+       */
       Version: `${number}.${number}.${number}`;
       PageTitle: string;
+
+      // I'm not sure I understand what this should represent in the end.
+      // I thought it was "Unique identifier for the test run, e.g. git hash" but
+      // since git info is somewhere else, maybe not…
       TestName: string;
+
+      // This is set in the response
+      // Id: number
+
+      // What is the difference with RequestTimeStampMilliseconds?
+      RequestTimestamp: number;
+
+      // Does user need to input that? Or do we have automagic connection to guess it?
+      /**
+       * ID of the site in Siteimprove Intelligence Platform.
+       */
+      SiteId?: string;
+
+      // Defaults to the URL, but should be overridable to avoid localhost:3000
+      PageUrl?: string;
+
+      // Use git library to read this.
+      CommitInformation?: {
+        CommitHash: string;
+        GitOrigin: string;
+        Author: string;
+        Email: string;
+        CommitTimestamp: number;
+        Message: string;
+      };
+
+      ResultAggregates: Array<{
+        RuleId: string;
+        Failed: number;
+        Passed: number;
+
+        // Can we rename that "CantTell"?
+        Canttell: number;
+      }>;
+
+      // Is this the only performance info we want, or do we want the same breakdown
+      // that dory gets? (https://github.com/Siteimprove/dory/blob/main/packages/dory-audit/src/performance.ts)
+      CheckDuration: number;
     }
 
     /**
      * Prepare payload with metadata for creating pre-signed URL.
      */
     export function payload(
+      alfaVersion: `${number}.${number}.${number}`,
       PageTitle: string,
       TestName: string,
       timestamp: number
@@ -131,7 +180,7 @@ export namespace SIP {
         Version: alfaVersion,
         PageTitle,
         TestName,
-      };
+      } as unknown as Payload;
     }
 
     /**
@@ -153,6 +202,7 @@ export namespace SIP {
      * Prepare the configuration for the axios request
      */
     export function axiosConfig(
+      alfaVersion: `${number}.${number}.${number}`,
       page: Page,
       options: Options,
       override: { url?: string; timestamp?: number },
@@ -173,7 +223,7 @@ export namespace SIP {
 
       return {
         ...params(url, `${options.userName}:${options.apiKey}`),
-        data: JSON.stringify(payload(title, name, timestamp)),
+        data: JSON.stringify(payload(alfaVersion, title, name, timestamp)),
       };
     }
   }

--- a/packages/alfa-test-utils/src/report/sip.ts
+++ b/packages/alfa-test-utils/src/report/sip.ts
@@ -1,6 +1,8 @@
 import { Array } from "@siteimprove/alfa-array";
 import { Element, Query } from "@siteimprove/alfa-dom";
 import { Serializable } from "@siteimprove/alfa-json";
+import { Err, Ok } from "@siteimprove/alfa-result";
+import type { Result } from "@siteimprove/alfa-result";
 import { Sequence } from "@siteimprove/alfa-sequence";
 import type { Page } from "@siteimprove/alfa-web";
 
@@ -36,7 +38,7 @@ export namespace SIP {
   export async function upload(
     audit: Audit.Result,
     options: Options
-  ): Promise<string>;
+  ): Promise<Result<string, string>>;
 
   /**
    * Internal overload for tests, allowing
@@ -50,13 +52,13 @@ export namespace SIP {
     audit: Audit.Result,
     options: Options,
     override: { url?: string; timestamp?: string; httpsAgent?: HttpsAgent }
-  ): Promise<string>;
+  ): Promise<Result<string, string>>;
 
   export async function upload(
     audit: Audit.Result,
     options: Options,
     override: { url?: string; timestamp?: string; HttpsAgent?: HttpsAgent } = {}
-  ): Promise<string> {
+  ): Promise<Result<string, string>> {
     const config = await Metadata.axiosConfig(audit, options, override);
 
     try {
@@ -65,12 +67,12 @@ export namespace SIP {
 
       await axios.request(S3.axiosConfig(id, preSignedUrl, audit));
 
-      return pageReportUrl;
+      return Ok.of(pageReportUrl);
     } catch (error) {
       console.error(error);
     }
 
-    return "Could not retrieve a page report URL";
+    return Err.of("Could not retrieve a page report URL");
   }
 
   /**

--- a/packages/alfa-test-utils/src/report/sip.ts
+++ b/packages/alfa-test-utils/src/report/sip.ts
@@ -129,7 +129,10 @@ export namespace SIP {
    * @internal
    */
   export namespace Metadata {
-    interface Payload {
+    /**
+     * @internal
+     */
+    export interface Payload {
       /**
        * The time the request is sent, formatted as an ISO 8601 string.
        */

--- a/packages/alfa-test-utils/src/report/sip.ts
+++ b/packages/alfa-test-utils/src/report/sip.ts
@@ -7,9 +7,8 @@ import { Sequence } from "@siteimprove/alfa-sequence";
 import type { AxiosRequestConfig } from "axios";
 import axios from "axios";
 
-import type { Audit } from "../audit/audit.js";
-import { getCommitInformation } from "./git.js";
-import type { CommitInformation } from "./git.js";
+import type { Audit, Performance } from "../audit/index.js";
+import { type CommitInformation, getCommitInformation } from "./git.js";
 
 const { Verbosity } = Serializable;
 
@@ -131,7 +130,37 @@ export namespace SIP {
        * Version of Alfa used for the checks
        */
       Version: `${number}.${number}.${number}`;
+
+      // Ignored for now.
+      // /**
+      //  * The site ID to which the page belongs in the Siteimprove Intelligence Platform.
+      //  */
+      // SiteId?: string;
+
+      /**
+       * Information about the latest git commit
+       */
+      CommitInformation?: CommitInformation;
+
+      // Ignored for now.
+      // /**
+      //  * Back link to a URL of choice, typically a link to the Pull Request
+      //  * containing the changes, …
+      //  */
+      // BackLink?: string;
+
+      /**
+       * The title of the page checked, defaults to the first `<title>` element
+       * if any, or "Unnamed page" if none.
+       */
       PageTitle: string;
+
+      /**
+       * The URL of the page. Defaults to the URL but can be overwritten to
+       * avoid `localhost` addresses in local tests, …
+       */
+      // Defaults to the URL, but should be overridable to avoid localhost:3000
+      // PageUrl: string;
 
       // I'm not sure I understand what this should represent in the end.
       // I thought it was "Unique identifier for the test run, e.g. git hash" but
@@ -139,21 +168,11 @@ export namespace SIP {
       // string | CommitInfo => string
       TestName: string;
 
-      // Ignored for now.
-      // SiteId?: string;
-
-      // Defaults to the URL, but should be overridable to avoid localhost:3000
-      // PageUrl: string;
-
-      CommitInformation?: CommitInformation;
-
       ResultAggregates: Array<Audit.RuleAggregate>;
 
       // Is this the only performance info we want, or do we want the same breakdown
       // that dory gets? (https://github.com/Siteimprove/dory/blob/main/packages/dory-audit/src/performance.ts)
-      // CheckDuration: number;
-
-      // PR id in GitInfo
+      CheckDurations: Performance.Durations;
     }
 
     /**
@@ -188,7 +207,8 @@ export namespace SIP {
         Version: audit.alfaVersion,
         PageTitle: title,
         TestName: name,
-        ResultAggregates: Array.from(audit.ResultAggregates),
+        ResultAggregates: Array.from(audit.resultAggregates),
+        CheckDurations: audit.durations,
       };
 
       for (const git of gitInfo) {
@@ -221,7 +241,8 @@ export namespace SIP {
       options: Options,
       override: { url?: string; timestamp?: string }
     ): Promise<AxiosRequestConfig> {
-      const { url = Defaults.URL, timestamp = new Date().toISOString() } = override;
+      const { url = Defaults.URL, timestamp = new Date().toISOString() } =
+        override;
 
       return {
         ...params(url, `${options.userName}:${options.apiKey}`),

--- a/packages/alfa-test-utils/src/report/sip.ts
+++ b/packages/alfa-test-utils/src/report/sip.ts
@@ -91,6 +91,16 @@ export namespace SIP {
     apiKey: string;
 
     /**
+     * The URL of the page, or a function to build it from the audited page.
+     * Defaults to the URL used to scrape the page.
+     *
+     * @remarks
+     * Overwriting it typically allows to circumvent `localhost` addresses for
+     * tests that are run on local servers.
+     */
+    pageURL?: string | ((page: Page) => string);
+
+    /**
      * The title of the page, or a function to build it from the audited page.
      * Defaults to the content of the first `<title>` element, if any.
      */
@@ -157,8 +167,7 @@ export namespace SIP {
        * The URL of the page. Defaults to the URL but can be overwritten to
        * avoid `localhost` addresses in local tests, …
        */
-      // Defaults to the URL, but should be overridable to avoid localhost:3000
-      // PageUrl: string;
+      PageUrl: string;
 
       /**
        * Name of the test, e.g. "AA conformance", "Color contrast",
@@ -192,6 +201,9 @@ export namespace SIP {
       defaultTitle = Defaults.Title,
       defaultName = Defaults.Name
     ): Promise<Payload> {
+      const url = options.pageURL ?? audit.page.response.url.toString();
+      const PageUrl = typeof url === "string" ? url : url(audit.page);
+
       const title =
         options.pageTitle ??
         Query.getElementDescendants(audit.page.document)
@@ -217,6 +229,7 @@ export namespace SIP {
       const result: Payload = {
         RequestTimestamp: timestamp,
         Version: audit.alfaVersion,
+        PageUrl,
         PageTitle,
         TestName,
         ResultAggregates: Array.from(audit.resultAggregates),

--- a/packages/alfa-test-utils/src/report/sip.ts
+++ b/packages/alfa-test-utils/src/report/sip.ts
@@ -123,6 +123,7 @@ export namespace SIP {
    */
   export namespace Metadata {
     interface Payload {
+      // sends as formated date string RequestTimeStamp
       RequestTimeStampMilliseconds: number;
       /**
        * Version of Alfa used for the checks
@@ -133,15 +134,17 @@ export namespace SIP {
       // I'm not sure I understand what this should represent in the end.
       // I thought it was "Unique identifier for the test run, e.g. git hash" but
       // since git info is somewhere else, maybe not…
+      // string | CommitInfo => string
       TestName: string;
 
       /**
        * ID of the site in Siteimprove Intelligence Platform.
        */
+      // ignore for now.
       // SiteId?: string;
 
       // Defaults to the URL, but should be overridable to avoid localhost:3000
-      // PageUrl?: string;
+      // PageUrl: string;
 
       CommitInformation?: CommitInformation;
 
@@ -150,6 +153,8 @@ export namespace SIP {
       // Is this the only performance info we want, or do we want the same breakdown
       // that dory gets? (https://github.com/Siteimprove/dory/blob/main/packages/dory-audit/src/performance.ts)
       // CheckDuration: number;
+
+      // PR id in GitInfo
     }
 
     /**

--- a/packages/alfa-test-utils/src/report/sip.ts
+++ b/packages/alfa-test-utils/src/report/sip.ts
@@ -163,16 +163,22 @@ export namespace SIP {
       // Defaults to the URL, but should be overridable to avoid localhost:3000
       // PageUrl: string;
 
-      // I'm not sure I understand what this should represent in the end.
-      // I thought it was "Unique identifier for the test run, e.g. git hash" but
-      // since git info is somewhere else, maybe not…
-      // string | CommitInfo => string
+      /**
+       * Name of the test, e.g. "AA conformance", "Color contrast",
+       * "On branch: \<branch name\>", …
+       */
       TestName: string;
 
+      /**
+       * Aggregated data for the results with number of Passed, Failed, and
+       * CantTell occurrences per rule.
+       */
       ResultAggregates: Array<Audit.RuleAggregate>;
 
-      // Is this the only performance info we want, or do we want the same breakdown
-      // that dory gets? (https://github.com/Siteimprove/dory/blob/main/packages/dory-audit/src/performance.ts)
+      /**
+       * Performances of the audit, with durations per rules and some common
+       * durations.
+       */
       CheckDurations: Performance.Durations;
     }
 

--- a/packages/alfa-test-utils/src/report/sip.ts
+++ b/packages/alfa-test-utils/src/report/sip.ts
@@ -50,13 +50,13 @@ export namespace SIP {
   export async function upload(
     audit: Audit.Result,
     options: Options,
-    override: { url?: string; timestamp?: number }
+    override: { url?: string; timestamp?: string }
   ): Promise<string>;
 
   export async function upload(
     audit: Audit.Result,
     options: Options,
-    override: { url?: string; timestamp?: number } = {}
+    override: { url?: string; timestamp?: string } = {}
   ): Promise<string> {
     const config = await Metadata.axiosConfig(audit, options, override);
 
@@ -123,8 +123,10 @@ export namespace SIP {
    */
   export namespace Metadata {
     interface Payload {
-      // sends as formated date string RequestTimeStamp
-      RequestTimeStampMilliseconds: number;
+      /**
+       * The time the request is sent, formatted as an ISO 8601 string.
+       */
+      RequestTimestamp: string;
       /**
        * Version of Alfa used for the checks
        */
@@ -137,10 +139,7 @@ export namespace SIP {
       // string | CommitInfo => string
       TestName: string;
 
-      /**
-       * ID of the site in Siteimprove Intelligence Platform.
-       */
-      // ignore for now.
+      // Ignored for now.
       // SiteId?: string;
 
       // Defaults to the URL, but should be overridable to avoid localhost:3000
@@ -159,11 +158,14 @@ export namespace SIP {
 
     /**
      * Prepare payload with metadata for creating pre-signed URL.
+     *
+     * @remarks
+     * The timestamp must be formated as an ISO 8601 formatted string.
      */
     export async function payload(
       audit: Audit.Result,
       options: Partial<Options>,
-      timestamp: number,
+      timestamp: string,
       defaultTitle = Defaults.Title,
       defaultName = Defaults.Name
     ): Promise<Payload> {
@@ -182,7 +184,7 @@ export namespace SIP {
           : Err.of("Skip git information as per configuration options");
 
       const result: Payload = {
-        RequestTimeStampMilliseconds: timestamp,
+        RequestTimestamp: timestamp,
         Version: audit.alfaVersion,
         PageTitle: title,
         TestName: name,
@@ -217,9 +219,9 @@ export namespace SIP {
     export async function axiosConfig(
       audit: Audit.Result,
       options: Options,
-      override: { url?: string; timestamp?: number }
+      override: { url?: string; timestamp?: string }
     ): Promise<AxiosRequestConfig> {
-      const { url = Defaults.URL, timestamp = Date.now() } = override;
+      const { url = Defaults.URL, timestamp = new Date().toISOString() } = override;
 
       return {
         ...params(url, `${options.userName}:${options.apiKey}`),

--- a/packages/alfa-test-utils/src/tsconfig.json
+++ b/packages/alfa-test-utils/src/tsconfig.json
@@ -9,6 +9,7 @@
     "audit/index.ts",
     "audit/outcomes.ts",
     "audit/rules.ts",
+    "report/git.ts",
     "report/index.ts",
     "report/sip.ts"
   ]

--- a/packages/alfa-test-utils/src/tsconfig.json
+++ b/packages/alfa-test-utils/src/tsconfig.json
@@ -8,6 +8,7 @@
     "audit/audit.ts",
     "audit/index.ts",
     "audit/outcomes.ts",
+    "audit/performance.ts",
     "audit/rules.ts",
     "report/git.ts",
     "report/index.ts",

--- a/packages/alfa-test-utils/test/audit/audit.spec.tsx
+++ b/packages/alfa-test-utils/test/audit/audit.spec.tsx
@@ -141,7 +141,6 @@ test(".run build performance data", async (t) => {
   const actual = (
     await Audit.run(page, {
       rules: { include: Rules.cherryPickFilter(2) },
-      outcomes: { exclude: Outcomes.failedFilter },
     })
   ).durations;
 

--- a/packages/alfa-test-utils/test/audit/audit.spec.tsx
+++ b/packages/alfa-test-utils/test/audit/audit.spec.tsx
@@ -17,25 +17,25 @@ const isTriple: Predicate<number> = (n) => n % 3 === 0;
 
 const numbers = Sequence.from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
-test(".filter keeps everything when no filter is provided", (t) => {
+test(".filter() keeps everything when no filter is provided", (t) => {
   t.deepEqual(Audit.filter(numbers, {}).toJSON(), numbers.toJSON());
 });
 
-test(".filter only includes specified items", (t) => {
+test(".filter() only includes specified items", (t) => {
   t.deepEqual(
     Audit.filter(numbers, { include: isEven }).toJSON(),
     [2, 4, 6, 8]
   );
 });
 
-test(".filter excludes specified items", (t) => {
+test(".filter() excludes specified items", (t) => {
   t.deepEqual(
     Audit.filter(numbers, { exclude: isEven }).toJSON(),
     [1, 3, 5, 7, 9]
   );
 });
 
-test(".filter prioritizes exclusion over inclusion", (t) => {
+test(".filter() prioritizes exclusion over inclusion", (t) => {
   t.deepEqual(
     Audit.filter(numbers, { include: isEven, exclude: isTriple }).toJSON(),
     [2, 4, 8]
@@ -63,7 +63,7 @@ const page = Page.of(
 
 const ruleFoo = makeRule(1001, foo, [Criterion.of("1.1.1")]);
 
-test(".run only runs included rules", async (t) => {
+test(".run() only runs included rules", async (t) => {
   const actual = (
     await Audit.run(page, {
       rules: { include: Rules.cherryPickFilter(2) },
@@ -75,7 +75,7 @@ test(".run only runs included rules", async (t) => {
   ]);
 });
 
-test(".run does not run excluded rules", async (t) => {
+test(".run() does not run excluded rules", async (t) => {
   const actual = (
     await Audit.run(page, {
       rules: { exclude: Rules.cherryPickFilter(2) },
@@ -90,7 +90,7 @@ test(".run does not run excluded rules", async (t) => {
   );
 });
 
-test(".run adds custom rules to the ruleset", async (t) => {
+test(".run() adds custom rules to the ruleset", async (t) => {
   const actual = (
     await Audit.run(page, {
       rules: { include: Rules.cherryPickFilter(2), custom: [ruleFoo] },
@@ -103,7 +103,7 @@ test(".run adds custom rules to the ruleset", async (t) => {
   ]);
 });
 
-test(".run overrides the ruleset with custom rules", async (t) => {
+test(".run() overrides the ruleset with custom rules", async (t) => {
   const actual = (
     await Audit.run(page, {
       rules: {
@@ -119,7 +119,7 @@ test(".run overrides the ruleset with custom rules", async (t) => {
   ]);
 });
 
-test(".run only keeps selected outcomes", async (t) => {
+test(".run() only keeps selected outcomes", async (t) => {
   const actual = (
     await Audit.run(page, {
       rules: { include: Rules.cherryPickFilter(2) },
@@ -133,7 +133,7 @@ test(".run only keeps selected outcomes", async (t) => {
   t.deepEqual(actual.toJSON(), ["foo"]);
 });
 
-test(".run excludes selected outcomes", async (t) => {
+test(".run() excludes selected outcomes", async (t) => {
   const actual = (
     await Audit.run(page, {
       rules: { include: Rules.cherryPickFilter(2) },
@@ -147,7 +147,7 @@ test(".run excludes selected outcomes", async (t) => {
   t.deepEqual(actual.toJSON(), ["bar"]);
 });
 
-test(".run build performance data", async (t) => {
+test(".run() build performance data", async (t) => {
   const actual = (
     await Audit.run(page, {
       rules: { include: Rules.cherryPickFilter(2) },

--- a/packages/alfa-test-utils/test/audit/audit.spec.tsx
+++ b/packages/alfa-test-utils/test/audit/audit.spec.tsx
@@ -136,3 +136,26 @@ test(".run excludes selected outcomes", async (t) => {
 
   t.deepEqual(actual.toJSON(), ["bar"]);
 });
+
+test(".run build performance data", async (t) => {
+  const actual = (
+    await Audit.run(page, {
+      rules: { include: Rules.cherryPickFilter(2) },
+      outcomes: { exclude: Outcomes.failedFilter },
+    })
+  ).durations;
+
+  // We cannot test real values due to instability, only checking they've been
+  // updated.
+  t.notEqual(actual.common.total, 0);
+  t.notEqual(actual.common.cascade, 0);
+  t.notEqual(actual.common["aria-tree"], 0);
+
+  t.deepEqual(Object.keys(actual.rules), [
+    "https://alfa.siteimprove.com/rules/sia-r2",
+  ]);
+  const rule = actual.rules["https://alfa.siteimprove.com/rules/sia-r2"];
+  t.notEqual(rule.total, 0);
+  t.notEqual(rule.applicability, 0);
+  t.notEqual(rule.expectation, 0);
+});

--- a/packages/alfa-test-utils/test/report/git.spec.ts
+++ b/packages/alfa-test-utils/test/report/git.spec.ts
@@ -20,7 +20,7 @@ test("getCommitInformation reads info from git", async (t) => {
   t(values.GitOrigin!.includes("Siteimprove/alfa-integrations"));
 
   for (const property of [
-    "Branch",
+    "BranchName",
     "CommitHash",
     "Author",
     "Email",

--- a/packages/alfa-test-utils/test/report/git.spec.ts
+++ b/packages/alfa-test-utils/test/report/git.spec.ts
@@ -1,0 +1,31 @@
+import { test } from "@siteimprove/alfa-test";
+import { getCommitInformation } from "../../dist/report/git.js";
+
+/**
+ * This test will fail if the origin URL is changed, e.g. on forks.
+ */
+test("getCommitInformation reads info from git", async (t) => {
+  // We pretty much cannot test the validity of the information since anything
+  // but the remote URL is by definition unstable. However, that information should
+  // exist on every state we are in.
+
+  const actual = await getCommitInformation();
+
+  t(actual.isOk());
+
+  const values = actual.getUnsafe();
+
+  t.equal(values.GitOrigin, "git@github.com:Siteimprove/alfa-integrations.git");
+
+  for (const property of [
+    "Branch",
+    "CommitHash",
+    "Author",
+    "Email",
+    "CommitTimestamp",
+    "Message",
+  ] as const) {
+    t.notEqual(values[property], undefined);
+    t.notEqual(values[property], "");
+  }
+});

--- a/packages/alfa-test-utils/test/report/git.spec.ts
+++ b/packages/alfa-test-utils/test/report/git.spec.ts
@@ -7,7 +7,8 @@ import { getCommitInformation } from "../../dist/report/git.js";
 test("getCommitInformation reads info from git", async (t) => {
   // We pretty much cannot test the validity of the information since anything
   // but the remote URL is by definition unstable. However, that information should
-  // exist on every state we are in.
+  // exist on every state we are in. It may however be different between the ssh
+  // and https version of the URL, so just checking org + repo.
 
   const actual = await getCommitInformation();
 
@@ -15,7 +16,8 @@ test("getCommitInformation reads info from git", async (t) => {
 
   const values = actual.getUnsafe();
 
-  t.equal(values.GitOrigin, "git@github.com:Siteimprove/alfa-integrations.git");
+  t.notEqual(values.GitOrigin, undefined);
+  t(values.GitOrigin!.includes("Siteimprove/alfa-integrations"));
 
   for (const property of [
     "Branch",

--- a/packages/alfa-test-utils/test/report/sip.spec.tsx
+++ b/packages/alfa-test-utils/test/report/sip.spec.tsx
@@ -46,6 +46,21 @@ function makeAudit(
   };
 }
 
+const emptyPayload: SIP.Metadata.Payload = {
+  RequestTimestamp: timestamp,
+  Version: alfaVersion,
+  PageUrl: "https://example.com/",
+  PageTitle: SIP.Defaults.Title,
+  TestName: SIP.Defaults.Name,
+  ResultAggregates: [],
+  CheckDurations: Performance.empty(),
+};
+function makePayload(
+  override: Partial<SIP.Metadata.Payload> = {}
+): SIP.Metadata.Payload {
+  return { ...emptyPayload, ...override };
+}
+
 /**
  * Commit information is highly unstable, hence we simply test that it exist
  * and delete it before deep equality testing. We could also use getCommitInformation
@@ -54,23 +69,11 @@ function makeAudit(
  */
 
 test("Metadata.payload() creates a payload", async (t) => {
-  const actual = await Metadata.payload(
-    makeAudit(),
-    { pageTitle: "title", testName: "name" },
-    timestamp
-  );
+  const actual = await Metadata.payload(makeAudit(), {}, timestamp);
   t.notEqual(actual.CommitInformation, undefined);
   delete actual.CommitInformation;
 
-  t.deepEqual(actual, {
-    RequestTimestamp: timestamp,
-    Version: alfaVersion,
-    PageUrl: "https://example.com/",
-    PageTitle: "title",
-    TestName: "name",
-    ResultAggregates: [],
-    CheckDurations: Performance.empty(),
-  });
+  t.deepEqual(actual, makePayload());
 });
 
 test("S3.payload() creates empty-ish payload", (t) => {
@@ -197,15 +200,7 @@ test("Metadata.payload() uses test name if provided", async (t) => {
   t.notEqual(actual.CommitInformation, undefined);
   delete actual.CommitInformation;
 
-  t.deepEqual(actual, {
-    RequestTimestamp: timestamp,
-    Version: alfaVersion,
-    PageUrl: "https://example.com/",
-    PageTitle: SIP.Defaults.Title,
-    TestName: "test name",
-    ResultAggregates: [],
-    CheckDurations: Performance.empty(),
-  });
+  t.deepEqual(actual, makePayload({ TestName: "test name" }));
 });
 
 test("Metadata.payload() builds test name from git information", async (t) => {
@@ -224,15 +219,10 @@ test("Metadata.payload() builds test name from git information", async (t) => {
   t.notEqual(actual.CommitInformation, undefined);
   delete actual.CommitInformation;
 
-  t.deepEqual(actual, {
-    RequestTimestamp: timestamp,
-    Version: alfaVersion,
-    PageUrl: "https://example.com/",
-    PageTitle: SIP.Defaults.Title,
-    TestName: "Siteimprove/alfa-integrations",
-    ResultAggregates: [],
-    CheckDurations: Performance.empty(),
-  });
+  t.deepEqual(
+    actual,
+    makePayload({ TestName: "Siteimprove/alfa-integrations" })
+  );
 });
 
 test("Metadata.payload() uses explicit title if provided", async (t) => {
@@ -244,15 +234,7 @@ test("Metadata.payload() uses explicit title if provided", async (t) => {
   t.notEqual(actual.CommitInformation, undefined);
   delete actual.CommitInformation;
 
-  t.deepEqual(actual, {
-    RequestTimestamp: timestamp,
-    Version: alfaVersion,
-    PageUrl: "https://example.com/",
-    PageTitle: "page title",
-    TestName: SIP.Defaults.Name,
-    ResultAggregates: [],
-    CheckDurations: Performance.empty(),
-  });
+  t.deepEqual(actual, makePayload({ PageTitle: "page title" }));
 });
 
 test("Metadata.payload() uses page's title if it exists", async (t) => {
@@ -262,15 +244,7 @@ test("Metadata.payload() uses page's title if it exists", async (t) => {
   t.notEqual(actual.CommitInformation, undefined);
   delete actual.CommitInformation;
 
-  t.deepEqual(actual, {
-    RequestTimestamp: timestamp,
-    Version: alfaVersion,
-    PageUrl: "https://example.com/",
-    PageTitle: "Hello",
-    TestName: SIP.Defaults.Name,
-    ResultAggregates: [],
-    CheckDurations: Performance.empty(),
-  });
+  t.deepEqual(actual, makePayload({ PageTitle: "Hello" }));
 });
 
 test("Metadata.payload() uses explicit title over page's title", async (t) => {
@@ -284,15 +258,7 @@ test("Metadata.payload() uses explicit title over page's title", async (t) => {
   t.notEqual(actual.CommitInformation, undefined);
   delete actual.CommitInformation;
 
-  t.deepEqual(actual, {
-    RequestTimestamp: timestamp,
-    Version: alfaVersion,
-    PageUrl: "https://example.com/",
-    PageTitle: "page title",
-    TestName: SIP.Defaults.Name,
-    ResultAggregates: [],
-    CheckDurations: Performance.empty(),
-  });
+  t.deepEqual(actual, makePayload({ PageTitle: "page title" }));
 });
 
 test("Metadata.payload() builds page title from the page if specified", async (t) => {
@@ -306,15 +272,10 @@ test("Metadata.payload() builds page title from the page if specified", async (t
   t.notEqual(actual.CommitInformation, undefined);
   delete actual.CommitInformation;
 
-  t.deepEqual(actual, {
-    RequestTimestamp: timestamp,
-    Version: alfaVersion,
-    PageUrl: "https://example.com/",
-    PageTitle: "#document\n  <span>\n    Hello\n  </span>",
-    TestName: SIP.Defaults.Name,
-    ResultAggregates: [],
-    CheckDurations: Performance.empty(),
-  });
+  t.deepEqual(
+    actual,
+    makePayload({ PageTitle: "#document\n  <span>\n    Hello\n  </span>" })
+  );
 });
 
 test("Metadata.payload() excludes commit information if requested", async (t) => {
@@ -325,15 +286,7 @@ test("Metadata.payload() excludes commit information if requested", async (t) =>
   );
   t.equal(actual.CommitInformation, undefined);
 
-  t.deepEqual(actual, {
-    RequestTimestamp: timestamp,
-    Version: alfaVersion,
-    PageUrl: "https://example.com/",
-    PageTitle: SIP.Defaults.Title,
-    TestName: SIP.Defaults.Name,
-    ResultAggregates: [],
-    CheckDurations: Performance.empty(),
-  });
+  t.deepEqual(actual, makePayload());
 });
 
 // Somehow, importing axios-mock-adapter breaks typing.

--- a/packages/alfa-test-utils/test/report/sip.spec.tsx
+++ b/packages/alfa-test-utils/test/report/sip.spec.tsx
@@ -52,7 +52,7 @@ const emptyPayload: SIP.Metadata.Payload = {
   PageTitle: SIP.Defaults.Title,
   TestName: SIP.Defaults.Name,
   ResultAggregates: [],
-  Durations: Performance.empty(),
+  Durations: { Cascade: 0, AriaTree: 0, Total: 0 },
 };
 function makePayload(
   override: Partial<SIP.Metadata.Payload> = {}
@@ -102,7 +102,7 @@ test("S3.payload serialises outcomes as string", async (t) => {
       Map.from([
         [
           "https://alfa.siteimprove.com/rules/sia-r1000",
-          { Failed: 1, Passed: 0, CantTell: 0 },
+          { failed: 1, passed: 0, cantTell: 0 },
         ],
       ])
     )

--- a/packages/alfa-test-utils/test/report/sip.spec.tsx
+++ b/packages/alfa-test-utils/test/report/sip.spec.tsx
@@ -52,7 +52,7 @@ const emptyPayload: SIP.Metadata.Payload = {
   PageTitle: SIP.Defaults.Title,
   TestName: SIP.Defaults.Name,
   ResultAggregates: [],
-  CheckDurations: Performance.empty(),
+  Durations: Performance.empty(),
 };
 function makePayload(
   override: Partial<SIP.Metadata.Payload> = {}

--- a/packages/alfa-test-utils/test/report/sip.spec.tsx
+++ b/packages/alfa-test-utils/test/report/sip.spec.tsx
@@ -32,8 +32,6 @@ const emptyAudit: Audit.Result = {
   ResultAggregates: [],
 };
 
-// TODO: move the title/name tests from axiosConfig to payload which is now using them.
-
 test("Metadata.payload() creates a payload", (t) => {
   const actual = Metadata.payload(
     emptyAudit,
@@ -187,33 +185,31 @@ test("S3.axiosConfig() creates an axios config", (t) => {
   });
 });
 
-test("Metadata.axiosConfig() uses test name if provided", (t) => {
-  const actual = Metadata.axiosConfig(
-    emptyAudit,
-    { userName: "foo@foo.com", apiKey: "bar", testName: "test name" },
-    { url: "https://foo.com", timestamp: 0 }
-  );
+test("Metadata.payload() uses test name if provided", (t) => {
+  const actual = Metadata.payload(emptyAudit, { testName: "test name" }, 0);
 
   t.deepEqual(actual, {
-    ...Metadata.params("https://foo.com", "foo@foo.com:bar"),
-    data: JSON.stringify(Metadata.payload(emptyAudit, {}, 0)),
+    RequestTimeStampMilliseconds: 0,
+    Version: alfaVersion,
+    PageTitle: SIP.Defaults.Title,
+    TestName: "test name",
+    ResultAggregates: [],
   });
 });
 
-test("Metadata.axiosConfig() uses explicit title if provided", (t) => {
-  const actual = Metadata.axiosConfig(
-    emptyAudit,
-    { userName: "foo@foo.com", apiKey: "bar", pageTitle: "page title" },
-    { url: "https://foo.com", timestamp: 0 }
-  );
+test("Metadata.payload() uses explicit title if provided", (t) => {
+  const actual = Metadata.payload(emptyAudit, { pageTitle: "page title" }, 0);
 
   t.deepEqual(actual, {
-    ...Metadata.params("https://foo.com", "foo@foo.com:bar"),
-    data: JSON.stringify(Metadata.payload(emptyAudit, {}, 0)),
+    RequestTimeStampMilliseconds: 0,
+    Version: alfaVersion,
+    PageTitle: "page title",
+    TestName: SIP.Defaults.Name,
+    ResultAggregates: [],
   });
 });
 
-test("Metadata.axiosConfig() uses page's title if it exists", (t) => {
+test("Metadata.payload() uses page's title if it exists", (t) => {
   const page = makePage(h.document([<title>Hello</title>, <span></span>]));
 
   const audit: Audit.Result = {
@@ -222,19 +218,18 @@ test("Metadata.axiosConfig() uses page's title if it exists", (t) => {
     outcomes: Sequence.empty(),
     ResultAggregates: [],
   };
-  const actual = Metadata.axiosConfig(
-    audit,
-    { userName: "foo@foo.com", apiKey: "bar" },
-    { url: "https://foo.com", timestamp: 0 }
-  );
+  const actual = Metadata.payload(audit, {}, 0);
 
   t.deepEqual(actual, {
-    ...Metadata.params("https://foo.com", "foo@foo.com:bar"),
-    data: JSON.stringify(Metadata.payload(audit, { pageTitle: "Hello" }, 0)),
+    RequestTimeStampMilliseconds: 0,
+    Version: alfaVersion,
+    PageTitle: "Hello",
+    TestName: SIP.Defaults.Name,
+    ResultAggregates: [],
   });
 });
 
-test("Metadata.axiosConfig() uses explicit title over page's title", (t) => {
+test("Metadata.payload() uses explicit title over page's title", (t) => {
   const page = makePage(h.document([<title>ignored</title>, <span></span>]));
 
   const audit: Audit.Result = {
@@ -243,17 +238,14 @@ test("Metadata.axiosConfig() uses explicit title over page's title", (t) => {
     outcomes: Sequence.empty(),
     ResultAggregates: [],
   };
-  const actual = Metadata.axiosConfig(
-    audit,
-    { userName: "foo@foo.com", apiKey: "bar", pageTitle: "page title" },
-    { url: "https://foo.com", timestamp: 0 }
-  );
+  const actual = Metadata.payload(audit, { pageTitle: "page title" }, 0);
 
   t.deepEqual(actual, {
-    ...Metadata.params("https://foo.com", "foo@foo.com:bar"),
-    data: JSON.stringify(
-      Metadata.payload(audit, { pageTitle: "page title" }, 0)
-    ),
+    RequestTimeStampMilliseconds: 0,
+    Version: alfaVersion,
+    PageTitle: "page title",
+    TestName: SIP.Defaults.Name,
+    ResultAggregates: [],
   });
 });
 

--- a/packages/alfa-test-utils/test/report/sip.spec.tsx
+++ b/packages/alfa-test-utils/test/report/sip.spec.tsx
@@ -20,6 +20,7 @@ const { Verbosity } = Serializable;
 const { Metadata, S3 } = SIP;
 
 const device = Device.standard();
+const timestamp = new Date().toISOString();
 
 function makePage(document: Document): Page {
   return Page.of(Request.empty(), Response.empty(), document, device);
@@ -43,13 +44,13 @@ test("Metadata.payload() creates a payload", async (t) => {
   const actual = await Metadata.payload(
     emptyAudit,
     { pageTitle: "title", testName: "name" },
-    0
+    timestamp
   );
   t.notEqual(actual.CommitInformation, undefined);
   delete actual.CommitInformation;
 
   t.deepEqual(actual, {
-    RequestTimeStampMilliseconds: 0,
+    RequestTimestamp: timestamp,
     Version: alfaVersion,
     PageTitle: "title",
     TestName: "name",
@@ -156,12 +157,12 @@ test("Metadata.axiosConfig() creates an axios config", async (t) => {
   const actual = await Metadata.axiosConfig(
     emptyAudit,
     { userName: "foo@foo.com", apiKey: "bar" },
-    { url: "https://foo.com", timestamp: 0 }
+    { url: "https://foo.com", timestamp }
   );
 
   t.deepEqual(actual, {
     ...Metadata.params("https://foo.com", "foo@foo.com:bar"),
-    data: JSON.stringify(await Metadata.payload(emptyAudit, {}, 0)),
+    data: JSON.stringify(await Metadata.payload(emptyAudit, {}, timestamp)),
   });
 });
 test("S3.axiosConfig() creates an axios config", (t) => {
@@ -198,13 +199,13 @@ test("Metadata.payload() uses test name if provided", async (t) => {
   const actual = await Metadata.payload(
     emptyAudit,
     { testName: "test name" },
-    0
+    timestamp
   );
   t.notEqual(actual.CommitInformation, undefined);
   delete actual.CommitInformation;
 
   t.deepEqual(actual, {
-    RequestTimeStampMilliseconds: 0,
+    RequestTimestamp: timestamp,
     Version: alfaVersion,
     PageTitle: SIP.Defaults.Title,
     TestName: "test name",
@@ -216,13 +217,13 @@ test("Metadata.payload() uses explicit title if provided", async (t) => {
   const actual = await Metadata.payload(
     emptyAudit,
     { pageTitle: "page title" },
-    0
+    timestamp
   );
   t.notEqual(actual.CommitInformation, undefined);
   delete actual.CommitInformation;
 
   t.deepEqual(actual, {
-    RequestTimeStampMilliseconds: 0,
+    RequestTimestamp: timestamp,
     Version: alfaVersion,
     PageTitle: "page title",
     TestName: SIP.Defaults.Name,
@@ -239,12 +240,12 @@ test("Metadata.payload() uses page's title if it exists", async (t) => {
     outcomes: Sequence.empty(),
     ResultAggregates: [],
   };
-  const actual = await Metadata.payload(audit, {}, 0);
+  const actual = await Metadata.payload(audit, {}, timestamp);
   t.notEqual(actual.CommitInformation, undefined);
   delete actual.CommitInformation;
 
   t.deepEqual(actual, {
-    RequestTimeStampMilliseconds: 0,
+    RequestTimestamp: timestamp,
     Version: alfaVersion,
     PageTitle: "Hello",
     TestName: SIP.Defaults.Name,
@@ -261,12 +262,16 @@ test("Metadata.payload() uses explicit title over page's title", async (t) => {
     outcomes: Sequence.empty(),
     ResultAggregates: [],
   };
-  const actual = await Metadata.payload(audit, { pageTitle: "page title" }, 0);
+  const actual = await Metadata.payload(
+    audit,
+    { pageTitle: "page title" },
+    timestamp
+  );
   t.notEqual(actual.CommitInformation, undefined);
   delete actual.CommitInformation;
 
   t.deepEqual(actual, {
-    RequestTimeStampMilliseconds: 0,
+    RequestTimestamp: timestamp,
     Version: alfaVersion,
     PageTitle: "page title",
     TestName: SIP.Defaults.Name,
@@ -278,12 +283,12 @@ test("Metadata.payload() excludes commit information if requested", async (t) =>
   const actual = await Metadata.payload(
     emptyAudit,
     { includeGitInfo: false },
-    0
+    timestamp
   );
   t.equal(actual.CommitInformation, undefined);
 
   t.deepEqual(actual, {
-    RequestTimeStampMilliseconds: 0,
+    RequestTimestamp: timestamp,
     Version: alfaVersion,
     PageTitle: SIP.Defaults.Title,
     TestName: SIP.Defaults.Name,

--- a/packages/alfa-test-utils/test/report/sip.spec.tsx
+++ b/packages/alfa-test-utils/test/report/sip.spec.tsx
@@ -200,6 +200,32 @@ test("Metadata.payload() uses test name if provided", async (t) => {
   });
 });
 
+test("Metadata.payload() builds test name from git information", async (t) => {
+  const actual = await Metadata.payload(
+    makeAudit(),
+    // Only the repo name is stable
+    {
+      testName: (git) =>
+        git.GitOrigin!.replace(
+          /.*Siteimprove\/alfa-integrations.*/,
+          "Siteimprove/alfa-integrations"
+        ),
+    },
+    timestamp
+  );
+  t.notEqual(actual.CommitInformation, undefined);
+  delete actual.CommitInformation;
+
+  t.deepEqual(actual, {
+    RequestTimestamp: timestamp,
+    Version: alfaVersion,
+    PageTitle: SIP.Defaults.Title,
+    TestName: "Siteimprove/alfa-integrations",
+    ResultAggregates: [],
+    CheckDurations: Performance.empty(),
+  });
+});
+
 test("Metadata.payload() uses explicit title if provided", async (t) => {
   const actual = await Metadata.payload(
     makeAudit(),

--- a/packages/alfa-test-utils/test/report/sip.spec.tsx
+++ b/packages/alfa-test-utils/test/report/sip.spec.tsx
@@ -201,6 +201,9 @@ test("Metadata.payload() uses test name if provided", async (t) => {
   t.deepEqual(actual, makePayload({ TestName: "test name" }));
 });
 
+/**
+ * This test will fail if the origin is changed, e.g. on forks.
+ */
 test("Metadata.payload() builds test name from git information", async (t) => {
   const actual = await Metadata.payload(
     makeAudit(),

--- a/packages/alfa-test-utils/test/report/sip.spec.tsx
+++ b/packages/alfa-test-utils/test/report/sip.spec.tsx
@@ -371,5 +371,5 @@ test(".upload connects to Siteimprove Intelligence Platform", async (t) => {
     apiKey: "bar",
   });
 
-  t.deepEqual(actual, "a page report URL");
+  t.deepEqual(actual.toJSON(), { type: "ok", value: "a page report URL" });
 });

--- a/packages/alfa-test-utils/test/report/sip.spec.tsx
+++ b/packages/alfa-test-utils/test/report/sip.spec.tsx
@@ -6,6 +6,7 @@ import { Serializable } from "@siteimprove/alfa-json";
 import { alfaVersion } from "@siteimprove/alfa-rules";
 import { Sequence } from "@siteimprove/alfa-sequence";
 import { test } from "@siteimprove/alfa-test";
+import { URL } from "@siteimprove/alfa-url";
 import { Page } from "@siteimprove/alfa-web";
 
 import axios from "axios";
@@ -23,7 +24,12 @@ const device = Device.standard();
 const timestamp = new Date().toISOString();
 
 function makePage(document: Document): Page {
-  return Page.of(Request.empty(), Response.empty(), document, device);
+  return Page.of(
+    Request.empty(),
+    Response.of(URL.example(), 200),
+    document,
+    device
+  );
 }
 
 function makeAudit(
@@ -59,6 +65,7 @@ test("Metadata.payload() creates a payload", async (t) => {
   t.deepEqual(actual, {
     RequestTimestamp: timestamp,
     Version: alfaVersion,
+    PageUrl: "https://example.com/",
     PageTitle: "title",
     TestName: "name",
     ResultAggregates: [],
@@ -193,6 +200,7 @@ test("Metadata.payload() uses test name if provided", async (t) => {
   t.deepEqual(actual, {
     RequestTimestamp: timestamp,
     Version: alfaVersion,
+    PageUrl: "https://example.com/",
     PageTitle: SIP.Defaults.Title,
     TestName: "test name",
     ResultAggregates: [],
@@ -219,6 +227,7 @@ test("Metadata.payload() builds test name from git information", async (t) => {
   t.deepEqual(actual, {
     RequestTimestamp: timestamp,
     Version: alfaVersion,
+    PageUrl: "https://example.com/",
     PageTitle: SIP.Defaults.Title,
     TestName: "Siteimprove/alfa-integrations",
     ResultAggregates: [],
@@ -238,6 +247,7 @@ test("Metadata.payload() uses explicit title if provided", async (t) => {
   t.deepEqual(actual, {
     RequestTimestamp: timestamp,
     Version: alfaVersion,
+    PageUrl: "https://example.com/",
     PageTitle: "page title",
     TestName: SIP.Defaults.Name,
     ResultAggregates: [],
@@ -255,6 +265,7 @@ test("Metadata.payload() uses page's title if it exists", async (t) => {
   t.deepEqual(actual, {
     RequestTimestamp: timestamp,
     Version: alfaVersion,
+    PageUrl: "https://example.com/",
     PageTitle: "Hello",
     TestName: SIP.Defaults.Name,
     ResultAggregates: [],
@@ -276,6 +287,7 @@ test("Metadata.payload() uses explicit title over page's title", async (t) => {
   t.deepEqual(actual, {
     RequestTimestamp: timestamp,
     Version: alfaVersion,
+    PageUrl: "https://example.com/",
     PageTitle: "page title",
     TestName: SIP.Defaults.Name,
     ResultAggregates: [],
@@ -288,7 +300,7 @@ test("Metadata.payload() builds page title from the page if specified", async (t
 
   const actual = await Metadata.payload(
     makeAudit(page),
-    { pageTitle: page => page.document.toString() },
+    { pageTitle: (page) => page.document.toString() },
     timestamp
   );
   t.notEqual(actual.CommitInformation, undefined);
@@ -297,12 +309,13 @@ test("Metadata.payload() builds page title from the page if specified", async (t
   t.deepEqual(actual, {
     RequestTimestamp: timestamp,
     Version: alfaVersion,
+    PageUrl: "https://example.com/",
     PageTitle: "#document\n  <span>\n    Hello\n  </span>",
     TestName: SIP.Defaults.Name,
     ResultAggregates: [],
     CheckDurations: Performance.empty(),
   });
-})
+});
 
 test("Metadata.payload() excludes commit information if requested", async (t) => {
   const actual = await Metadata.payload(
@@ -315,6 +328,7 @@ test("Metadata.payload() excludes commit information if requested", async (t) =>
   t.deepEqual(actual, {
     RequestTimestamp: timestamp,
     Version: alfaVersion,
+    PageUrl: "https://example.com/",
     PageTitle: SIP.Defaults.Title,
     TestName: SIP.Defaults.Name,
     ResultAggregates: [],

--- a/packages/alfa-test-utils/test/report/sip.spec.tsx
+++ b/packages/alfa-test-utils/test/report/sip.spec.tsx
@@ -283,6 +283,27 @@ test("Metadata.payload() uses explicit title over page's title", async (t) => {
   });
 });
 
+test("Metadata.payload() builds page title from the page if specified", async (t) => {
+  const page = makePage(h.document([<span>Hello</span>]));
+
+  const actual = await Metadata.payload(
+    makeAudit(page),
+    { pageTitle: page => page.document.toString() },
+    timestamp
+  );
+  t.notEqual(actual.CommitInformation, undefined);
+  delete actual.CommitInformation;
+
+  t.deepEqual(actual, {
+    RequestTimestamp: timestamp,
+    Version: alfaVersion,
+    PageTitle: "#document\n  <span>\n    Hello\n  </span>",
+    TestName: SIP.Defaults.Name,
+    ResultAggregates: [],
+    CheckDurations: Performance.empty(),
+  });
+})
+
 test("Metadata.payload() excludes commit information if requested", async (t) => {
   const actual = await Metadata.payload(
     makeAudit(),

--- a/packages/alfa-test-utils/test/tsconfig.json
+++ b/packages/alfa-test-utils/test/tsconfig.json
@@ -12,6 +12,7 @@
     "./audit/outcomes.spec.tsx",
     "./audit/rules.spec.tsx",
     "./fixtures.ts",
+    "./report/git.spec.ts",
     "./report/sip.spec.tsx"
   ],
   "references": [{ "path": "../src" }]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1260,6 +1260,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@kwsites/file-exists@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@kwsites/file-exists@npm:1.1.1"
+  dependencies:
+    debug: ^4.1.1
+  checksum: 4ff945de7293285133aeae759caddc71e73c4a44a12fac710fdd4f574cce2671a3f89d8165fdb03d383cfc97f3f96f677d8de3c95133da3d0e12a123a23109fe
+  languageName: node
+  linkType: hard
+
+"@kwsites/promise-deferred@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@kwsites/promise-deferred@npm:1.1.1"
+  checksum: 07455477a0123d9a38afb503739eeff2c5424afa8d3dbdcc7f9502f13604488a4b1d9742fc7288832a52a6422cf1e1c0a1d51f69a39052f14d27c9a0420b6629
+  languageName: node
+  linkType: hard
+
 "@manypkg/find-root@npm:^1.1.0":
   version: 1.1.0
   resolution: "@manypkg/find-root@npm:1.1.0"
@@ -3104,6 +3120,7 @@ __metadata:
     "@siteimprove/alfa-web": ^0.88.0
     axios: ^1.7.2
     axios-mock-adapter: ^1.22.0
+    simple-git: ^3.25.0
   languageName: unknown
   linkType: soft
 
@@ -11534,6 +11551,17 @@ fsevents@^2.3.2:
     once: ^1.3.1
     simple-concat: ^1.0.0
   checksum: 80195e70bf171486e75c31e28e5485468195cc42f85940f8b45c4a68472160144d223eb4d07bc82ef80cb974b7c401db021a540deb2d34ac4b3b8883da2d6401
+  languageName: node
+  linkType: hard
+
+"simple-git@npm:^3.25.0":
+  version: 3.25.0
+  resolution: "simple-git@npm:3.25.0"
+  dependencies:
+    "@kwsites/file-exists": ^1.1.1
+    "@kwsites/promise-deferred": ^1.1.1
+    debug: ^4.3.5
+  checksum: 0f54f03882f3b733fc5b61826935b3a6b1d2f8976fe74a488ef72d05baf1f8eb6f465867dcf72c1b7292b20843de23e900160c5c9b5d6933b3db2188cb79e1d2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3084,6 +3084,7 @@ __metadata:
   resolution: "@siteimprove/alfa-test-utils@workspace:packages/alfa-test-utils"
   dependencies:
     "@siteimprove/alfa-act": ^0.88.0
+    "@siteimprove/alfa-array": ^0.88.0
     "@siteimprove/alfa-css": ^0.88.0
     "@siteimprove/alfa-device": ^0.88.0
     "@siteimprove/alfa-dom": ^0.88.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3100,7 +3100,9 @@ __metadata:
   resolution: "@siteimprove/alfa-test-utils@workspace:packages/alfa-test-utils"
   dependencies:
     "@siteimprove/alfa-act": ^0.88.0
+    "@siteimprove/alfa-aria": ^0.88.0
     "@siteimprove/alfa-array": ^0.88.0
+    "@siteimprove/alfa-cascade": ^0.88.0
     "@siteimprove/alfa-css": ^0.88.0
     "@siteimprove/alfa-device": ^0.88.0
     "@siteimprove/alfa-dom": ^0.88.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3109,6 +3109,7 @@ __metadata:
     "@siteimprove/alfa-http": ^0.88.0
     "@siteimprove/alfa-iterable": ^0.88.0
     "@siteimprove/alfa-json": ^0.88.0
+    "@siteimprove/alfa-map": ^0.88.0
     "@siteimprove/alfa-option": ^0.88.0
     "@siteimprove/alfa-performance": ^0.88.0
     "@siteimprove/alfa-predicate": ^0.88.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3108,6 +3108,7 @@ __metadata:
     "@siteimprove/alfa-iterable": ^0.88.0
     "@siteimprove/alfa-json": ^0.88.0
     "@siteimprove/alfa-option": ^0.88.0
+    "@siteimprove/alfa-performance": ^0.88.0
     "@siteimprove/alfa-predicate": ^0.88.0
     "@siteimprove/alfa-record": ^0.88.0
     "@siteimprove/alfa-refinement": ^0.88.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3119,6 +3119,7 @@ __metadata:
     "@siteimprove/alfa-selector": ^0.88.0
     "@siteimprove/alfa-sequence": ^0.88.0
     "@siteimprove/alfa-test": ^0.88.0
+    "@siteimprove/alfa-url": ^0.88.0
     "@siteimprove/alfa-wcag": ^0.88.0
     "@siteimprove/alfa-web": ^0.88.0
     axios: ^1.7.2


### PR DESCRIPTION
Resolves II-8305

The README is extremely small, just showing basic use case, proper documentation will come later.
