### PR TITLE
Remove pre-built rule sets

### DIFF
--- a/docs/review/api/alfa-test-utils.api.md
+++ b/docs/review/api/alfa-test-utils.api.md
@@ -52,19 +52,12 @@ export namespace Outcomes {
 export namespace Rules {
     const allRules: Sequence<Flattened.Rule>;
     const aaFilter: Predicate<Flattened.Rule>;
-    const aaRules: Sequence<Flattened.Rule>;
     const wcag20Filter: Predicate<Flattened.Rule>;
-    const wcag20Rules: Sequence<Flattened.Rule>;
     const wcag20aaFilter: Predicate<Flattened.Rule>;
-    const wcag20aaRules: Sequence<Flattened.Rule>;
     const wcag21aaFilter: Predicate<Flattened.Rule>;
-    const wcag21aaRules: Sequence<Flattened.Rule>;
     const componentFilter: Predicate<Flattened.Rule>;
-    const componentRules: Sequence<Flattened.Rule>;
     export function cherryPickFilter(rulesId: Array<number>): Predicate<Flattened.Rule>;
     export function cherryPickFilter(...rulesId: Array<number>): Predicate<Flattened.Rule>;
-    export function cherryPickRules(rulesId: Array<number>): Sequence<Flattened.Rule>;
-    export function cherryPickRules(...rulesId: Array<number>): Sequence<Flattened.Rule>;
 }
 
 // @public

--- a/packages/alfa-test-utils/src/audit/rules.ts
+++ b/packages/alfa-test-utils/src/audit/rules.ts
@@ -3,7 +3,6 @@ import type { Predicate } from "@siteimprove/alfa-predicate";
 import { Refinement } from "@siteimprove/alfa-refinement";
 import rules, { Scope } from "@siteimprove/alfa-rules";
 import type { Flattened } from "@siteimprove/alfa-rules";
-import type { Sequence } from "@siteimprove/alfa-sequence";
 import { Conformance, Criterion } from "@siteimprove/alfa-wcag";
 
 const { and } = Refinement;
@@ -31,13 +30,6 @@ export namespace Rules {
    */
   export const aaFilter: Predicate<Flattened.Rule> = (rule) =>
     rule.hasRequirement(and(Criterion.isCriterion, Conformance.isAA()));
-  /**
-   * The AA conformance rules, i.e. rules for level A and AA success criteria.
-   *
-   * @remarks
-   * This considers rules for the latest recommendation, i.e. WCAG 2.2
-   */
-  export const aaRules = allRules.filter(aaFilter);
 
   /**
    * Filter matching the WCAG 2.0 rules.
@@ -48,30 +40,18 @@ export namespace Rules {
         Iterable.some(criterion.versions, (version) => version === "2.0")
       )
     );
-  /**
-   * The WCAG 2.0 rules.
-   */
-  export const wcag20Rules = allRules.filter(wcag20Filter);
 
   /**
    * Filter matching the WCAG 2.0 AA conformance rules.
    */
   export const wcag20aaFilter: Predicate<Flattened.Rule> = (rule) =>
     rule.hasRequirement(and(Criterion.isCriterion, Conformance.isAA("2.0")));
-  /**
-   * The WCAG 2.0 AA conformance rules.
-   */
-  export const wcag20aaRules = allRules.filter(wcag20aaFilter);
 
   /**
    * Filter matching the WCAG 2.1 AA conformance rules.
    */
   export const wcag21aaFilter: Predicate<Flattened.Rule> = (rule) =>
     rule.hasRequirement(and(Criterion.isCriterion, Conformance.isAA("2.1")));
-  /**
-   * The WCAG 2.1 AA conformance rules.
-   */
-  export const wcag21aaRules = allRules.filter(wcag21aaFilter);
 
   /**
    * Filter matching the "component" rules.
@@ -83,15 +63,6 @@ export namespace Rules {
    */
   export const componentFilter: Predicate<Flattened.Rule> = (rule) =>
     rule.hasTag((tag) => tag.equals(Scope.Component));
-  /**
-   * The "component" rules.
-   *
-   * @remarks
-   * This discards rules that only make sense in the context of a full page, e.g.
-   * skip link or presence of a title. It can be used to test design system pages
-   * that contain a single component to showcase it.
-   */
-  export const componentRules = allRules.filter(componentFilter);
 
   /**
    * Filter to manually cherry-pick rules, by their id.
@@ -126,30 +97,5 @@ export namespace Rules {
     );
 
     return (rule) => rulesURIs.includes(rule.uri);
-  }
-
-  /**
-   * Helper to build a list of cherry-picked rules.
-   */
-  export function cherryPickRules(
-    rulesId: Array<number>
-  ): Sequence<Flattened.Rule>;
-
-  /**
-   * Helper to build a list of cherry-picked rules.
-   */
-  export function cherryPickRules(
-    ...rulesId: Array<number>
-  ): Sequence<Flattened.Rule>;
-
-  export function cherryPickRules(
-    first: number | Array<number>,
-    ...rulesId: Array<number>
-  ) {
-    return allRules.filter(
-      typeof first === "number"
-        ? cherryPickFilter(first, ...rulesId)
-        : cherryPickFilter(first)
-    );
   }
 }


### PR DESCRIPTION
The audit is mostly using a filter-based model, so providing list of pre-filtered rules makes little sense.
