### PR TITLE
Add peer dependencies to `alfa-test-utils`

### DIFF
--- a/packages/alfa-test-utils/package.json
+++ b/packages/alfa-test-utils/package.json
@@ -57,5 +57,31 @@
     "@siteimprove/alfa-test": "^0.89.0",
     "@siteimprove/alfa-url": "^0.89.0",
     "axios-mock-adapter": "^1.22.0"
+  },
+  "peerDependencies": {
+    "@siteimprove/alfa-act": "^0.89.0",
+    "@siteimprove/alfa-aria": "^0.89.0",
+    "@siteimprove/alfa-array": "^0.89.0",
+    "@siteimprove/alfa-cascade": "^0.89.0",
+    "@siteimprove/alfa-css": "^0.89.0",
+    "@siteimprove/alfa-device": "^0.89.0",
+    "@siteimprove/alfa-dom": "^0.89.0",
+    "@siteimprove/alfa-http": "^0.89.0",
+    "@siteimprove/alfa-iterable": "^0.89.0",
+    "@siteimprove/alfa-json": "^0.89.0",
+    "@siteimprove/alfa-map": "^0.89.0",
+    "@siteimprove/alfa-option": "^0.89.0",
+    "@siteimprove/alfa-performance": "^0.89.0",
+    "@siteimprove/alfa-predicate": "^0.89.0",
+    "@siteimprove/alfa-record": "^0.89.0",
+    "@siteimprove/alfa-refinement": "^0.89.0",
+    "@siteimprove/alfa-result": "^0.89.0",
+    "@siteimprove/alfa-rules": "^0.89.0",
+    "@siteimprove/alfa-selector": "^0.89.0",
+    "@siteimprove/alfa-sequence": "^0.89.0",
+    "@siteimprove/alfa-test": "^0.89.0",
+    "@siteimprove/alfa-url": "^0.89.0",
+    "@siteimprove/alfa-wcag": "^0.89.0",
+    "@siteimprove/alfa-web": "^0.89.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3127,6 +3127,31 @@ __metadata:
     axios-mock-adapter: ^1.22.0
     chalk: ^5.3.0
     simple-git: ^3.25.0
+  peerDependencies:
+    "@siteimprove/alfa-act": ^0.89.0
+    "@siteimprove/alfa-aria": ^0.89.0
+    "@siteimprove/alfa-array": ^0.89.0
+    "@siteimprove/alfa-cascade": ^0.89.0
+    "@siteimprove/alfa-css": ^0.89.0
+    "@siteimprove/alfa-device": ^0.89.0
+    "@siteimprove/alfa-dom": ^0.89.0
+    "@siteimprove/alfa-http": ^0.89.0
+    "@siteimprove/alfa-iterable": ^0.89.0
+    "@siteimprove/alfa-json": ^0.89.0
+    "@siteimprove/alfa-map": ^0.89.0
+    "@siteimprove/alfa-option": ^0.89.0
+    "@siteimprove/alfa-performance": ^0.89.0
+    "@siteimprove/alfa-predicate": ^0.89.0
+    "@siteimprove/alfa-record": ^0.89.0
+    "@siteimprove/alfa-refinement": ^0.89.0
+    "@siteimprove/alfa-result": ^0.89.0
+    "@siteimprove/alfa-rules": ^0.89.0
+    "@siteimprove/alfa-selector": ^0.89.0
+    "@siteimprove/alfa-sequence": ^0.89.0
+    "@siteimprove/alfa-test": ^0.89.0
+    "@siteimprove/alfa-url": ^0.89.0
+    "@siteimprove/alfa-wcag": ^0.89.0
+    "@siteimprove/alfa-web": ^0.89.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This should hopefully give some warning when trying to use it with a mismatching Alfa version 🤞 