### PR TITLE
Use builduser token for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "github>siteimprove/alfa/config/alfa-renovate"],
+  "extends": ["config:base", "github>siteimprove/alfa//config/alfa-renovate"],
   "npmrc": "@siteimprove:registry=https://npm.pkg.github.com/",
   "hostRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "github>siteimprove/alfa//config/alfa-renovate"],
+  "extends": ["config:base", "github>siteimprove/alfa/config/alfa-renovate"],
+  "npmrc": "@siteimprove:registry=https://npm.pkg.github.com/",
+  "hostRules": [
+    {
+      "hostType": "npm",
+      "matchHost": "https://npm.pkg.github.com/",
+      "token": "{{ secrets.BUILDUSER_GITHUB_READ }}"
+    }
+  ]
   "packageRules": [
     {
       "description": [


### PR DESCRIPTION
Use the builduser token for Renovate.
Since this still uses the Github registry from its `yarnrc` file, it needs a token to read the packages.