### PR TITLE
Increase maximum size of payload

### DIFF
--- a/.changeset/fifty-trainers-tease.md
+++ b/.changeset/fifty-trainers-tease.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-test-utils": patch
+---
+
+**Fixed:** Increase the maximum size of pages that can be uploaded.

--- a/packages/alfa-test-utils/src/report/sip.ts
+++ b/packages/alfa-test-utils/src/report/sip.ts
@@ -477,11 +477,23 @@ export namespace SIP {
       url: string,
       audit: Audit | Audit.JSON
     ): AxiosRequestConfig {
+      const value = payload(id, audit);
       return {
         ...params(url),
-        data: new Blob([JSON.stringify(payload(id, audit))], {
-          type: "application/json",
-        }),
+        data: new Blob(
+          [
+            // Calling JSON.stringify directly on the payload causes
+            // RangeError: Invalid string length
+            // on large payloads. Doing it piecewise (and manually) avoids the
+            // problem, or at least push it back to even larger payload where
+            // the individual pieces will also be too large. If we encounter
+            // this again, we may have to switch to a JSON streaming solution.
+            `{"Id":"${value.Id}","CheckResult":"${value.CheckResult}","Aspects":"${value.Aspects}"}`,
+          ],
+          {
+            type: "application/json",
+          }
+        ),
       };
     }
   }

--- a/packages/alfa-test-utils/test/report/sip.spec.tsx
+++ b/packages/alfa-test-utils/test/report/sip.spec.tsx
@@ -197,10 +197,13 @@ test("S3.axiosConfig() creates an axios config", (t) => {
     makeAudit({ page })
   );
 
+  const payload = S3.payload("some id", makeAudit({ page }));
   t.deepEqual(actual, {
     ...S3.params("a pre-signed S3 URL"),
     data: new Blob(
-      [JSON.stringify(S3.payload("some id", makeAudit({ page })))],
+      [
+        `{"Id":"${payload.Id}","CheckResult":"${payload.CheckResult}","Aspects":"${payload.Aspects}"}`,
+      ],
       {
         type: "application/json",
       }
@@ -217,10 +220,13 @@ test("S3.axiosConfig() accepts serialized audits", (t) => {
     makeAudit({ page }).toJSON()
   );
 
+  const payload = S3.payload("some id", makeAudit({ page }));
   t.deepEqual(actual, {
     ...S3.params("a pre-signed S3 URL"),
     data: new Blob(
-      [JSON.stringify(S3.payload("some id", makeAudit({ page })))],
+      [
+        `{"Id":"${payload.Id}","CheckResult":"${payload.CheckResult}","Aspects":"${payload.Aspects}"}`,
+      ],
       {
         type: "application/json",
       }
@@ -616,6 +622,8 @@ test(".upload returns Axios error message in case of 5XX", async (t) => {
 
   t.deepEqual(actual.toJSON(), {
     type: "err",
-    error: ["Server error (503): Request failed with status code 503. Try again later or contact support if the issue persists."],
+    error: [
+      "Server error (503): Request failed with status code 503. Try again later or contact support if the issue persists.",
+    ],
   });
 });


### PR DESCRIPTION
Large payloads cause an exception in `JSON.stringify`. Splitting the stringification improves that (or at least pushes the limit). This seems to be sufficient for now, but we might have to switch to better stringification libraries.