### PR TITLE
Clean up changelog after invalid release attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Alfa integrations changelog
 
-## [](../../compare/v...v) (2025-07-30)
-
-
-
 ## [0.80.0](../../compare/v0.79.4...v0.80.0) (2025-07-28)
 
 ### Changed


### PR DESCRIPTION
I accidentally ran the release job without having merged the PR that would bump the version. This resulted in the job failing after it had modified the changelog. This just reverts that change.