### PR TITLE
Update Cypress

### DIFF
--- a/packages/alfa-cypress/package.json
+++ b/packages/alfa-cypress/package.json
@@ -36,7 +36,7 @@
     "@siteimprove/alfa-mapper": "^0.114.3",
     "@siteimprove/alfa-url": "^0.114.3",
     "@siteimprove/alfa-web": "^0.114.3",
-    "cypress": "^15.13.1"
+    "cypress": "^15.14.0"
   },
   "peerDependencies": {
     "@siteimprove/alfa-act": "^0.114.3",

--- a/packages/alfa-cypress/tsconfig.json
+++ b/packages/alfa-cypress/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
-  "compilerOptions": { "ignoreDeprecations": "6.0" },
   "references": [{ "path": "./src" }, { "path": "./test" }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4251,7 +4251,7 @@ __metadata:
     "@siteimprove/alfa-mapper": "npm:^0.114.3"
     "@siteimprove/alfa-url": "npm:^0.114.3"
     "@siteimprove/alfa-web": "npm:^0.114.3"
-    cypress: "npm:^15.13.1"
+    cypress: "npm:^15.14.0"
   peerDependencies:
     "@siteimprove/alfa-act": ^0.114.3
     "@siteimprove/alfa-device": ^0.114.3
@@ -8037,9 +8037,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:^15.13.1":
-  version: 15.13.1
-  resolution: "cypress@npm:15.13.1"
+"cypress@npm:^15.14.0":
+  version: 15.14.0
+  resolution: "cypress@npm:15.14.0"
   dependencies:
     "@cypress/request": "npm:^3.0.10"
     "@cypress/xvfb": "npm:^1.2.4"
@@ -8086,7 +8086,7 @@ __metadata:
     yauzl: "npm:^2.10.0"
   bin:
     cypress: bin/cypress
-  checksum: 10/93eac22e89e7727fd1867734cf876de9dafaa7c902309509c76668420f113df2a1cf889c27726de73946dca3d3f111186d2e33bcce8225430e3492f89e44b012
+  checksum: 10/a49de9b3af2bca33e1895262a466745f65697f744aefe59c994c3929aa03f185eb3d4b61aa9c751aec4eb19a6cda2b9f1988f1d367700ba0303bdb5bec31691b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update Cypress to a version that works with TS6, and remove the TS6 deprecation warning skip.
