### PR TITLE
Fix ambient type declaration in `alfa-vitest`

### DIFF
--- a/.changeset/khaki-berries-train.md
+++ b/.changeset/khaki-berries-train.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-vitest": patch
+---
+
+**Fixed:** The ambient type declaration for `.toBeAccessible` now correctly matches Vitest 4.x syntax.

--- a/packages/alfa-vitest/src/vitest.ts
+++ b/packages/alfa-vitest/src/vitest.ts
@@ -7,13 +7,10 @@ import type { Mapper } from "@siteimprove/alfa-mapper";
 
 import { expect } from "vitest";
 
-interface CustomMatchers<R = unknown> {
-  toBeAccessible: () => R;
-}
-
 declare module "vitest" {
-  interface Assertion<T = any> extends CustomMatchers<T> {}
-  interface AsymmetricMatchersContaining extends CustomMatchers {}
+  interface Matchers<T = any> {
+    toBeAccessible: () => T;
+  }
 }
 
 /**
@@ -25,12 +22,12 @@ export namespace Vitest {
     J,
     T extends Hashable,
     Q extends Question.Metadata = {},
-    S = T
+    S = T,
   >(
     transform: Mapper<I, Future.Maybe<J>>,
     rules: Iterable<Rule<J, T, Q, S>>,
     handlers: Iterable<Handler<J, T, Q, S>> = [],
-    options: Asserter.Options<J, T, Q, S> = {}
+    options: Asserter.Options<J, T, Q, S> = {},
   ): void {
     const asserter = Asserter.of(rules, handlers, options);
 


### PR DESCRIPTION
The type declaration of custom matchers has changed in Vitest 4.x:
* [Vitest 3.x declarations](https://v3.vitest.dev/guide/extending-matchers.html)
* [Vitest 4.x declarations](https://vitest.dev/guide/extending-matchers)
