### PR TITLE
Update Node and actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -20,15 +20,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        # 20 is in Maintenance until April 2026.
-        # 22 is Active until October 2025, Maintenance until April 2027.
-        # 24 is Current from April 2025 to October 2025, then Active until October 2026, Maintenance until April 2028.
-        # 26 will be Current in April 2026.
+        # 22 is in Maintenance until April 2027.
+        # 24 is Active until October 2026, Maintenance until April 2028.
+        # 26 is Current from May 2026 to October 2026, then Active until October 2027, Maintenance until April 2029.
+        # 28 will be Current in April/May 2027.
         # https://nodejs.org/en/about/previous-releases
-        node: [ 20, 22, 24 ]
+        node: [ 22, 24, 26 ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -25,7 +25,10 @@ jobs:
         # 26 is Current from May 2026 to October 2026, then Active until October 2027, Maintenance until April 2029.
         # 28 will be Current in April/May 2027.
         # https://nodejs.org/en/about/previous-releases
-        node: [ 22, 24, 26 ]
+        #
+        # There is a problem in v26 + webdriver (see Vitest config file) which has been backported in Node 24.16,
+        # so we stay on a working minor for now, rather than disable too many webdriver tests.
+        node: [ 22, 24.14, 26 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -28,7 +28,7 @@ jobs:
         #
         # There is a problem in v26 + webdriver (see Vitest config file) which has been backported in Node 24.16,
         # so we stay on a working minor for now, rather than disable too many webdriver tests.
-        node: [ 22, 24 ]
+        node: [ 22, 24.14, 26 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -61,10 +61,7 @@ jobs:
         # creating a PR and running this workflow…
         run: yarn test-main || yarn test-main
 
-      - name: Run other tests
-        run: |
-          yarn workspace @siteimprove/alfa-cypress run cypress install
-          yarn test-other
+      - run: yarn test-other
       - run: yarn validate-structure
       - run: yarn extract --quiet
       - run: yarn knip

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -28,7 +28,7 @@ jobs:
         #
         # There is a problem in v26 + webdriver (see Vitest config file) which has been backported in Node 24.16,
         # so we stay on a working minor for now, rather than disable too many webdriver tests.
-        node: [ 22, 24.14, 26 ]
+        node: [ 22, 24.14 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -58,7 +58,10 @@ jobs:
         # creating a PR and running this workflow…
         run: yarn test-main || yarn test-main
 
-      - run: yarn test-other
+      - name: Run other tests
+        run: |
+          yarn workspace @siteimprove/alfa-cypress run cypress install
+          yarn test-other
       - run: yarn validate-structure
       - run: yarn extract --quiet
       - run: yarn knip

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -28,7 +28,7 @@ jobs:
         #
         # There is a problem in v26 + webdriver (see Vitest config file) which has been backported in Node 24.16,
         # so we stay on a working minor for now, rather than disable too many webdriver tests.
-        node: [ 22, 24.14 ]
+        node: [ 22, 24 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr-command.yml
+++ b/.github/workflows/pr-command.yml
@@ -31,8 +31,8 @@ jobs:
         if: env.PR_COMMAND_WILL_RUN == 'true'
         uses: actions/setup-node@v6
         with:
-          # We use versions 20 in the integrate workflow
-          node-version: 20
+          # 24 is Active from October 2025 to October 2026.
+          node-version: 24
 
       - name: Set up token for Github packages
         if: env.PR_COMMAND_WILL_RUN == 'true'

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -13,10 +13,11 @@ const exclude = [
 
 console.log(`Running on Node ${process.version}.`);
 
-if (process.version.includes("v26")) {
+if (process.version.startsWith("v26") || process.version.startsWith("v24.16")) {
   // Node26 is breaking the utterly outdated yauzl 2 and extract-zip, which are
   // used by webdriver to extract the puppeteer browser; plus some direct problem
-  // in webdriver HTTP headings.
+  // in webdriver HTTP headings. Node 24.16 had the same root cause backported
+  // and also causes the problem.
   // Until webdriver updates and fixes these problems, we simply skip the tests
   // in Node26. Given that the CI/CD also runs Node 22 and 24, this should be OK.
   // Another possibility is to forces yauzl resolution to 3.*, out of the semver
@@ -25,6 +26,10 @@ if (process.version.includes("v26")) {
   //
   // Monitor https://github.com/webdriverio/webdriverio/issues/15265 for updates
   // on Webdriver side.
+  // See also https://github.com/max-mapper/extract-zip/issues/154
+  //
+  // Also update the integrate workflow to unfix the minor Node 24 version once
+  // this is fixed upstream.
   console.log(
     "Skipping Webdriver tests due to Node26/yauzl/extract-zip incompatibility.",
   );

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -11,6 +11,8 @@ const exclude = [
   "packages/alfa-jest",
 ];
 
+console.log(`Running on Node ${process.version}.`);
+
 if (process.version.includes("v26")) {
   // Node26 is breaking the utterly outdated yauzl 2 and extract-zip, which are
   // used by webdriver to extract the puppeteer browser; plus some direct problem

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -1,18 +1,38 @@
 import { defineConfig } from "vitest/config";
 
+const exclude = [
+  // alfa-angular is tested through alfa-angular-test.
+  "packages/alfa-angular",
+  // Packages with integration to a tests launcher use that launcher, and are
+  // therefore skipped here. Use `yarn test-other` to run those.
+  "packages/alfa-angular-test",
+  "packages/alfa-cypress",
+  "packages/alfa-jasmine",
+  "packages/alfa-jest",
+];
+
+if (process.version.includes("v26")) {
+  // Node26 is breaking the utterly outdated yauzl 2 and extract-zip, which are
+  // used by webdriver to extract the puppeteer browser; plus some direct problem
+  // in webdriver HTTP headings.
+  // Until webdriver updates and fixes these problems, we simply skip the tests
+  // in Node26. Given that the CI/CD also runs Node 22 and 24, this should be OK.
+  // Another possibility is to forces yauzl resolution to 3.*, out of the semver
+  // range for extract-zip. However, (i) this does not fix the HTTP heading
+  // problem; and (ii) overrides out of semver is often a wonky fix at best.
+  //
+  // Monitor https://github.com/webdriverio/webdriverio/issues/15265 for updates
+  // on Webdriver side.
+  console.log(
+    "Skipping Webdriver tests due to Node26/yauzl/extract-zip incompatibility.",
+  );
+  exclude.push("packages/alfa-webdriver");
+}
+
 export default defineConfig({
   test: {
     include: ["packages/alfa-*/test/**/*.spec.ts?(x)"],
-    exclude: [
-      // alfa-angular is tested through alfa-angular-test.
-      "packages/alfa-angular",
-      // Packages with integration to a tests launcher use that launcher, and are
-      // therefore skipped here. Use `yarn test-other` to run those.
-      "packages/alfa-angular-test",
-      "packages/alfa-cypress",
-      "packages/alfa-jasmine",
-      "packages/alfa-jest",
-    ],
+    exclude,
     // Several tests, notably the ones that spawn a new browser instance, tend
     // to take a lot of time… Especially when launching all tests simultaneously.
     testTimeout: 60_000 /* ms */,

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -18,15 +18,17 @@ if (process.version.startsWith("v26") || process.version.startsWith("v24.16")) {
   // used by webdriver to extract the puppeteer browser; plus some direct problem
   // in webdriver HTTP headings. Node 24.16 had the same root cause backported
   // and also causes the problem.
-  // Until webdriver updates and fixes these problems, we simply skip the tests
-  // in Node26. Given that the CI/CD also runs Node 22 and 24, this should be OK.
+  // Until webdriver updates and fixes these problems, we simply skip its tests
+  // in Node26/24.16. Given that the CI/CD also runs Node 22 and 24.14, this
+  // should be OK.
   // Another possibility is to forces yauzl resolution to 3.*, out of the semver
   // range for extract-zip. However, (i) this does not fix the HTTP heading
   // problem; and (ii) overrides out of semver is often a wonky fix at best.
   //
   // Monitor https://github.com/webdriverio/webdriverio/issues/15265 for updates
   // on Webdriver side.
-  // See also https://github.com/max-mapper/extract-zip/issues/154
+  // See also https://github.com/max-mapper/extract-zip/issues/154 (unlikley to
+  // be acted upon as the last commits to that repo are from 2020).
   //
   // Also update the integrate workflow to unfix the minor Node 24 version once
   // this is fixed upstream.

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.7"
   },
+  "resolutions": {
+    "yauzl": "3.3.1"
+  },
   "packageManager": "yarn@4.15.0"
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "knip": "knip --config config/knip.ts --no-config-hints"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -43,8 +43,5 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.7"
   },
-  "resolutions": {
-    "yauzl": "3.3.1"
-  },
   "packageManager": "yarn@4.15.0"
 }

--- a/packages/alfa-angular-test/package.json
+++ b/packages/alfa-angular-test/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "ng": "ng",

--- a/packages/alfa-angular/package.json
+++ b/packages/alfa-angular/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "test": "echo 'This package is tested by @siteimprove/alfa-angular-test'"

--- a/packages/alfa-assert/package.json
+++ b/packages/alfa-assert/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-chai/package.json
+++ b/packages/alfa-chai/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-cheerio/package.json
+++ b/packages/alfa-cheerio/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-cli/package.json
+++ b/packages/alfa-cli/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "bin": {

--- a/packages/alfa-command/package.json
+++ b/packages/alfa-command/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-crawler/package.json
+++ b/packages/alfa-crawler/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-cypress/package.json
+++ b/packages/alfa-cypress/package.json
@@ -36,7 +36,7 @@
     "@siteimprove/alfa-mapper": "^0.114.3",
     "@siteimprove/alfa-url": "^0.114.3",
     "@siteimprove/alfa-web": "^0.114.3",
-    "cypress": "^15.14.2"
+    "cypress": "^15.16.0"
   },
   "peerDependencies": {
     "@siteimprove/alfa-act": "^0.114.3",

--- a/packages/alfa-cypress/package.json
+++ b/packages/alfa-cypress/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-formatter-earl/package.json
+++ b/packages/alfa-formatter-earl/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-formatter-json/package.json
+++ b/packages/alfa-formatter-json/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-formatter-sarif/package.json
+++ b/packages/alfa-formatter-sarif/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-formatter/package.json
+++ b/packages/alfa-formatter/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-frontier/package.json
+++ b/packages/alfa-frontier/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-interviewer/package.json
+++ b/packages/alfa-interviewer/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-jasmine/package.json
+++ b/packages/alfa-jasmine/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-jest/package.json
+++ b/packages/alfa-jest/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-jquery/package.json
+++ b/packages/alfa-jquery/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-playwright/package.json
+++ b/packages/alfa-playwright/package.json
@@ -27,7 +27,7 @@
     "@siteimprove/alfa-http": "^0.114.3",
     "@siteimprove/alfa-url": "^0.114.3",
     "@siteimprove/alfa-web": "^0.114.3",
-    "playwright": "^1.59.1"
+    "playwright": "^1.60.0"
   },
   "peerDependencies": {
     "@siteimprove/alfa-device": "^0.114.3",

--- a/packages/alfa-playwright/package.json
+++ b/packages/alfa-playwright/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-puppeteer/package.json
+++ b/packages/alfa-puppeteer/package.json
@@ -27,7 +27,7 @@
     "@siteimprove/alfa-http": "^0.114.3",
     "@siteimprove/alfa-url": "^0.114.3",
     "@siteimprove/alfa-web": "^0.114.3",
-    "puppeteer": "^24.42.0"
+    "puppeteer": "^25.1.0"
   },
   "peerDependencies": {
     "@siteimprove/alfa-device": "^0.114.3",
@@ -35,7 +35,7 @@
     "@siteimprove/alfa-http": "^0.114.3",
     "@siteimprove/alfa-url": "^0.114.3",
     "@siteimprove/alfa-web": "^0.114.3",
-    "puppeteer": "^24.0.0"
+    "puppeteer": "^25.1.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/alfa-puppeteer/package.json
+++ b/packages/alfa-puppeteer/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-react/package.json
+++ b/packages/alfa-react/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-scraper/package.json
+++ b/packages/alfa-scraper/package.json
@@ -37,7 +37,7 @@
     "@siteimprove/alfa-time": "^0.114.3",
     "@siteimprove/alfa-url": "^0.114.3",
     "@siteimprove/alfa-web": "^0.114.3",
-    "puppeteer": "^24.42.0"
+    "puppeteer": "^25.1.0"
   },
   "devDependencies": {
     "@siteimprove/alfa-test": "^0.114.3",

--- a/packages/alfa-scraper/package.json
+++ b/packages/alfa-scraper/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-selenium/package.json
+++ b/packages/alfa-selenium/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-test-utils/package.json
+++ b/packages/alfa-test-utils/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-unexpected/package.json
+++ b/packages/alfa-unexpected/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "src/index.js",

--- a/packages/alfa-vitest/package.json
+++ b/packages/alfa-vitest/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-vue/package.json
+++ b/packages/alfa-vue/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-webdriver/package.json
+++ b/packages/alfa-webdriver/package.json
@@ -12,7 +12,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/alfa-webdriver/package.json
+++ b/packages/alfa-webdriver/package.json
@@ -27,7 +27,7 @@
     "@siteimprove/alfa-http": "^0.114.3",
     "@siteimprove/alfa-url": "^0.114.3",
     "@siteimprove/alfa-web": "^0.114.3",
-    "webdriverio": "^9.27.1"
+    "webdriverio": "^9.27.2"
   },
   "peerDependencies": {
     "@siteimprove/alfa-device": "^0.114.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9284,6 +9284,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fd-slicer@npm:~1.1.0":
+  version: 1.1.0
+  resolution: "fd-slicer@npm:1.1.0"
+  dependencies:
+    pend: "npm:~1.2.0"
+  checksum: 10/db3e34fa483b5873b73f248e818f8a8b59a6427fd8b1436cd439c195fdf11e8659419404826059a642b57d18075c856d06d6a50a1413b714f12f833a9341ead3
+  languageName: node
+  linkType: hard
+
 "fdir@npm:^6.5.0":
   version: 6.5.0
   resolution: "fdir@npm:6.5.0"
@@ -15955,13 +15964,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yauzl@npm:3.3.1":
-  version: 3.3.1
-  resolution: "yauzl@npm:3.3.1"
+"yauzl@npm:^2.10.0":
+  version: 2.10.0
+  resolution: "yauzl@npm:2.10.0"
   dependencies:
     buffer-crc32: "npm:~0.2.3"
-    pend: "npm:~1.2.0"
-  checksum: 10/b9ecac2dca8cf0ce83d29e24ab66af50c2488f12630d0778c5190cc3ca898308986a3955fb6bbc8ee6fe21eae1691ec26068760a54d873f3930718be3bbd1ce3
+    fd-slicer: "npm:~1.1.0"
+  checksum: 10/1e4c311050dc0cf2ee3dbe8854fe0a6cde50e420b3e561a8d97042526b4cf7a0718d6c8d89e9e526a152f4a9cec55bcea9c3617264115f48bd6704cf12a04445
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3176,9 +3176,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@puppeteer/browsers@npm:2.13.0, @puppeteer/browsers@npm:^2.2.0":
-  version: 2.13.0
-  resolution: "@puppeteer/browsers@npm:2.13.0"
+"@puppeteer/browsers@npm:3.0.4":
+  version: 3.0.4
+  resolution: "@puppeteer/browsers@npm:3.0.4"
+  dependencies:
+    modern-tar: "npm:^0.7.6"
+    yargs: "npm:^17.7.2"
+  peerDependencies:
+    proxy-agent: ">=8.0.1"
+  peerDependenciesMeta:
+    proxy-agent:
+      optional: true
+  bin:
+    browsers: lib/main-cli.js
+  checksum: 10/189069e97c26e2a974fb93761209f46074c660e55d569280628964fc9842651b116dee0a9063804160ad7289f8af2590fa59b0b431bf93e9b36b97c58919fe10
+  languageName: node
+  linkType: hard
+
+"@puppeteer/browsers@npm:^2.2.0":
+  version: 2.13.2
+  resolution: "@puppeteer/browsers@npm:2.13.2"
   dependencies:
     debug: "npm:^4.4.3"
     extract-zip: "npm:^2.0.1"
@@ -3189,7 +3206,7 @@ __metadata:
     yargs: "npm:^17.7.2"
   bin:
     browsers: lib/cjs/main-cli.js
-  checksum: 10/f14f4fe098d8d4c60c7829beed7576963c7a8bb91f82091f78353738d297a014ccbc6630b1df2d736a30679f5f6ffbc6c17b5dac4d87d226aa57ab495d5e595f
+  checksum: 10/c0c74d8a5ab5b9f6a829f488002f63247d3c4dabfd57cab9944e1bde8ce13e568f86633cb38fdf89d234826b110b2bb570da9278c598fa409816234cdebf5166
   languageName: node
   linkType: hard
 
@@ -4977,14 +4994,14 @@ __metadata:
     "@siteimprove/alfa-test": "npm:^0.114.3"
     "@siteimprove/alfa-url": "npm:^0.114.3"
     "@siteimprove/alfa-web": "npm:^0.114.3"
-    puppeteer: "npm:^24.42.0"
+    puppeteer: "npm:^25.1.0"
   peerDependencies:
     "@siteimprove/alfa-device": ^0.114.3
     "@siteimprove/alfa-dom": ^0.114.3
     "@siteimprove/alfa-http": ^0.114.3
     "@siteimprove/alfa-url": ^0.114.3
     "@siteimprove/alfa-web": ^0.114.3
-    puppeteer: ^24.0.0
+    puppeteer: ^25.1.0
   languageName: unknown
   linkType: soft
 
@@ -5168,7 +5185,7 @@ __metadata:
     "@siteimprove/alfa-time": "npm:^0.114.3"
     "@siteimprove/alfa-url": "npm:^0.114.3"
     "@siteimprove/alfa-web": "npm:^0.114.3"
-    puppeteer: "npm:^24.42.0"
+    puppeteer: "npm:^25.1.0"
   peerDependencies:
     "@siteimprove/alfa-array": ^0.114.3
     "@siteimprove/alfa-device": ^0.114.3
@@ -5709,7 +5726,7 @@ __metadata:
     "@siteimprove/alfa-test": "npm:^0.114.3"
     "@siteimprove/alfa-url": "npm:^0.114.3"
     "@siteimprove/alfa-web": "npm:^0.114.3"
-    webdriverio: "npm:^9.27.1"
+    webdriverio: "npm:^9.27.2"
   peerDependencies:
     "@siteimprove/alfa-device": ^0.114.3
     "@siteimprove/alfa-dom": ^0.114.3
@@ -6529,18 +6546,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wdio/config@npm:9.27.1":
-  version: 9.27.1
-  resolution: "@wdio/config@npm:9.27.1"
+"@wdio/config@npm:9.27.2":
+  version: 9.27.2
+  resolution: "@wdio/config@npm:9.27.2"
   dependencies:
     "@wdio/logger": "npm:9.18.0"
-    "@wdio/types": "npm:9.27.1"
-    "@wdio/utils": "npm:9.27.1"
+    "@wdio/types": "npm:9.27.2"
+    "@wdio/utils": "npm:9.27.2"
     deepmerge-ts: "npm:^7.0.3"
     glob: "npm:^10.2.2"
     import-meta-resolve: "npm:^4.0.0"
     jiti: "npm:^2.6.1"
-  checksum: 10/6c7d2e848d7f0bb48ba49592dc1bf733421b8eed2c0ac177aec94693d0124d4f3e8ebbe6af6251bcbacd194943d49f6571d528c3120f77c338cdd0f6428bb891
+  checksum: 10/432956f72f350448ea9c271c34b21053f654feba6595bb7d52db5e957ff081bd49ba8a12fced8adc971668623a86fd7028f5dda80ac6da6929c0cdb8adb04396
   languageName: node
   linkType: hard
 
@@ -6557,10 +6574,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wdio/protocols@npm:9.27.1":
-  version: 9.27.1
-  resolution: "@wdio/protocols@npm:9.27.1"
-  checksum: 10/dca0c41ea8c459857bc01fc1cb3c030f42fa099e7fb61a4bcde45722841b93db6d406498999272139f51ef76abc6c08bdca0f35ef2a28357e922aee4a913a937
+"@wdio/protocols@npm:9.27.2":
+  version: 9.27.2
+  resolution: "@wdio/protocols@npm:9.27.2"
+  checksum: 10/b2c779b546b70fd878cb9b7c9303ef3ee982b0730115916e12979478a163a020ad74ca5ef05d21b8412ae83cfd01dd42dd3a740760fcd7d7afa816a8957cd973
   languageName: node
   linkType: hard
 
@@ -6573,22 +6590,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wdio/types@npm:9.27.1":
-  version: 9.27.1
-  resolution: "@wdio/types@npm:9.27.1"
+"@wdio/types@npm:9.27.2":
+  version: 9.27.2
+  resolution: "@wdio/types@npm:9.27.2"
   dependencies:
     "@types/node": "npm:^20.1.0"
-  checksum: 10/a29811401c1cf9c264136efc331ef2be31fc3be4834fdf938ee4a58ced86d6d8cefddd8492a38d156f2daaad9e96a5412b9536490936e75463b19158ac991c3e
+  checksum: 10/b1d0262923f7b7df5497063b2e8d49cd8833962f4ce829a13bb26cb715844dbb2d083fe72defb490d93cd566e324ee3336ebfce42fad3a0580d87ca6c927427f
   languageName: node
   linkType: hard
 
-"@wdio/utils@npm:9.27.1":
-  version: 9.27.1
-  resolution: "@wdio/utils@npm:9.27.1"
+"@wdio/utils@npm:9.27.2":
+  version: 9.27.2
+  resolution: "@wdio/utils@npm:9.27.2"
   dependencies:
     "@puppeteer/browsers": "npm:^2.2.0"
     "@wdio/logger": "npm:9.18.0"
-    "@wdio/types": "npm:9.27.1"
+    "@wdio/types": "npm:9.27.2"
     decamelize: "npm:^6.0.0"
     deepmerge-ts: "npm:^7.0.3"
     edgedriver: "npm:^6.1.2"
@@ -6600,7 +6617,7 @@ __metadata:
     safaridriver: "npm:^1.0.0"
     split2: "npm:^4.2.0"
     wait-port: "npm:^1.1.0"
-  checksum: 10/2b1bc84cc98be1b3133c377a5c74c6a2db0e8e6d7a7ed6f318726f3631c414cce1c32da1b74b65cc6299ccf8a4f9626c52bdc3973a071f84ad0b13823516efff
+  checksum: 10/1816fddd4c32e62528ce844ad0200718f17f87732e6e1103e2b787fe9b3a842d1f1f65a51a0d806246d7be92b5f9b050034b7cbb6ab652d62b2390f64c0b0bd9
   languageName: node
   linkType: hard
 
@@ -7477,7 +7494,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"callsites@npm:^3.0.0, callsites@npm:^3.1.0":
+"callsites@npm:^3.1.0":
   version: 3.1.0
   resolution: "callsites@npm:3.1.0"
   checksum: 10/072d17b6abb459c2ba96598918b55868af677154bec7e73d222ef95a8fdb9bbf7dae96a8421085cdad8cd190d86653b5b6dc55a4484f2e5b2e27d5e0c3fc15b3
@@ -7617,15 +7634,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromium-bidi@npm:14.0.0":
-  version: 14.0.0
-  resolution: "chromium-bidi@npm:14.0.0"
+"chromium-bidi@npm:16.0.1":
+  version: 16.0.1
+  resolution: "chromium-bidi@npm:16.0.1"
   dependencies:
     mitt: "npm:^3.0.1"
     zod: "npm:^3.24.1"
   peerDependencies:
     devtools-protocol: "*"
-  checksum: 10/b931d7fb459a6e2e27ce3aed97252656836e74e7d54c99582cead41e75c80479c77f3f1784ec5abf62e2a9b834ce0a76ef1deb998dfcfe09238d4133baab7d8a
+  checksum: 10/119c3e1dfb6b25aede226bb9de88198008bc7b0f59a063e62980eaf82e172fc11f0adacc207fab9b8a8ea8da974534088ef59b9a0a357a572bd43e3f6e92ef1b
   languageName: node
   linkType: hard
 
@@ -7966,23 +7983,6 @@ __metadata:
     object-assign: "npm:^4"
     vary: "npm:^1"
   checksum: 10/aa7174305b21ceb90f9c84f4eaa32f04432d333addbfdc0d1eb7310393c48902e5364aada5ac2f5d054528d63b3179238444475426fcb74e1e345077de485727
-  languageName: node
-  linkType: hard
-
-"cosmiconfig@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "cosmiconfig@npm:9.0.0"
-  dependencies:
-    env-paths: "npm:^2.2.1"
-    import-fresh: "npm:^3.3.0"
-    js-yaml: "npm:^4.1.0"
-    parse-json: "npm:^5.2.0"
-  peerDependencies:
-    typescript: ">=4.9.5"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/8bdf1dfbb6fdb3755195b6886dc0649a3c742ec75afa4cb8da7b070936aed22a4f4e5b7359faafe03180358f311dbc300d248fd6586c458203d376a40cc77826
   languageName: node
   linkType: hard
 
@@ -8436,10 +8436,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"devtools-protocol@npm:0.0.1595872":
-  version: 0.0.1595872
-  resolution: "devtools-protocol@npm:0.0.1595872"
-  checksum: 10/0352934308c37abc9c33e6c928d97a506d043ae7ad55c81766eed573ba0be3bb04b4703524e50a65c86c3e45a28290468732d2db7c5ca0bf3e3c30fc6aaba0cb
+"devtools-protocol@npm:0.0.1624250":
+  version: 0.0.1624250
+  resolution: "devtools-protocol@npm:0.0.1624250"
+  checksum: 10/13928de8f3db19ac67332ef49f9fe2ec064506b5637a3fd8304c996a50d4c06ab2fd262d384dc0002bf8425b41f40e0c533a51e7ed7ee4990409edcc71b4c05e
   languageName: node
   linkType: hard
 
@@ -8697,7 +8697,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"env-paths@npm:^2.2.0, env-paths@npm:^2.2.1":
+"env-paths@npm:^2.2.0":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 10/65b5df55a8bab92229ab2b40dad3b387fad24613263d103a97f91c9fe43ceb21965cd3392b1ccb5d77088021e525c4e0481adb309625d0cb94ade1d1fb8dc17e
@@ -9281,15 +9281,6 @@ __metadata:
   dependencies:
     walk-up-path: "npm:^4.0.0"
   checksum: 10/e595a1a23f8e208815cdcf26c92218240da00acce80468324408dc4a5cb6c26b6efb5076f0458a02f044562a1e60253731187a627d5416b4961468ddfc0ae426
-  languageName: node
-  linkType: hard
-
-"fd-slicer@npm:~1.1.0":
-  version: 1.1.0
-  resolution: "fd-slicer@npm:1.1.0"
-  dependencies:
-    pend: "npm:~1.2.0"
-  checksum: 10/db3e34fa483b5873b73f248e818f8a8b59a6427fd8b1436cd439c195fdf11e8659419404826059a642b57d18075c856d06d6a50a1413b714f12f833a9341ead3
   languageName: node
   linkType: hard
 
@@ -10062,16 +10053,6 @@ __metadata:
   version: 5.1.5
   resolution: "immutable@npm:5.1.5"
   checksum: 10/7aec2740239772ec8e92e793c991bd809203a97694f4ff3a18e50e28f9a6b02393ad033d87b458037bdf8c0ea37d4446d640e825f6171df3405cf6cf300ce028
-  languageName: node
-  linkType: hard
-
-"import-fresh@npm:^3.3.0":
-  version: 3.3.1
-  resolution: "import-fresh@npm:3.3.1"
-  dependencies:
-    parent-module: "npm:^1.0.0"
-    resolve-from: "npm:^4.0.0"
-  checksum: 10/a06b19461b4879cc654d46f8a6244eb55eb053437afd4cbb6613cad6be203811849ed3e4ea038783092879487299fda24af932b86bdfff67c9055ba3612b8c87
   languageName: node
   linkType: hard
 
@@ -11405,6 +11386,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lilconfig@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "lilconfig@npm:3.1.3"
+  checksum: 10/b932ce1af94985f0efbe8896e57b1f814a48c8dbd7fc0ef8469785c6303ed29d0090af3ccad7e36b626bfca3a4dc56cc262697e9a8dd867623cf09a39d54e4c3
+  languageName: node
+  linkType: hard
+
 "lines-and-columns@npm:^1.1.6":
   version: 1.2.4
   resolution: "lines-and-columns@npm:1.2.4"
@@ -11941,10 +11929,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"modern-tar@npm:^0.7.2":
-  version: 0.7.5
-  resolution: "modern-tar@npm:0.7.5"
-  checksum: 10/6991fe9b14c1c64fdb613003ef29c5a16f3dd40c60d0e04181503be21ebe8c155e49fe097e107b7970238d76ff5e2f15e2250f6edcb1ff95ec2b33cfa8bec23a
+"modern-tar@npm:^0.7.2, modern-tar@npm:^0.7.6":
+  version: 0.7.6
+  resolution: "modern-tar@npm:0.7.6"
+  checksum: 10/1cc7be85f155e8991c378d23e6240431cb9875422d493167929ec605220513180620fe6a38ae0d5c2636b535dbd7704aafb2eff62aa167fc661cd59120aa9632
   languageName: node
   linkType: hard
 
@@ -12731,15 +12719,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parent-module@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "parent-module@npm:1.0.1"
-  dependencies:
-    callsites: "npm:^3.0.0"
-  checksum: 10/6ba8b255145cae9470cf5551eb74be2d22281587af787a2626683a6c20fbb464978784661478dd2a3f1dad74d1e802d403e1b03c1a31fab310259eec8ac560ff
-  languageName: node
-  linkType: hard
-
 "parse-json@npm:^5.2.0":
   version: 5.2.0
   resolution: "parse-json@npm:5.2.0"
@@ -13256,34 +13235,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"puppeteer-core@npm:24.42.0":
-  version: 24.42.0
-  resolution: "puppeteer-core@npm:24.42.0"
+"puppeteer-core@npm:25.1.0":
+  version: 25.1.0
+  resolution: "puppeteer-core@npm:25.1.0"
   dependencies:
-    "@puppeteer/browsers": "npm:2.13.0"
-    chromium-bidi: "npm:14.0.0"
-    debug: "npm:^4.4.3"
-    devtools-protocol: "npm:0.0.1595872"
-    typed-query-selector: "npm:^2.12.1"
-    webdriver-bidi-protocol: "npm:0.4.1"
-    ws: "npm:^8.19.0"
-  checksum: 10/922ebac5339d61e7212fd9329f965de24485e17f2ce1cc24f528aadc401793232369f42bb89808e4414d52458defbe795801344600d63f835b85d2abd74e59b6
+    "@puppeteer/browsers": "npm:3.0.4"
+    chromium-bidi: "npm:16.0.1"
+    devtools-protocol: "npm:0.0.1624250"
+    typed-query-selector: "npm:^2.12.2"
+    webdriver-bidi-protocol: "npm:0.4.2"
+    ws: "npm:^8.21.0"
+  checksum: 10/1eb2bcedf76245cda4b9c3c8cf8196509049a59ccce2a159219863b1ee372a8772c50d8e0f987d9ee6eac09ffb48918aec5bdec5d929b88a7ee240b18e64a972
   languageName: node
   linkType: hard
 
-"puppeteer@npm:^24.42.0":
-  version: 24.42.0
-  resolution: "puppeteer@npm:24.42.0"
+"puppeteer@npm:^25.1.0":
+  version: 25.1.0
+  resolution: "puppeteer@npm:25.1.0"
   dependencies:
-    "@puppeteer/browsers": "npm:2.13.0"
-    chromium-bidi: "npm:14.0.0"
-    cosmiconfig: "npm:^9.0.0"
-    devtools-protocol: "npm:0.0.1595872"
-    puppeteer-core: "npm:24.42.0"
-    typed-query-selector: "npm:^2.12.1"
+    "@puppeteer/browsers": "npm:3.0.4"
+    chromium-bidi: "npm:16.0.1"
+    devtools-protocol: "npm:0.0.1624250"
+    lilconfig: "npm:^3.1.3"
+    puppeteer-core: "npm:25.1.0"
+    typed-query-selector: "npm:^2.12.2"
   bin:
-    puppeteer: lib/cjs/puppeteer/node/cli.js
-  checksum: 10/8369c18c4dba156c2da9d60b634917ebd56ee5bab6b185acadef140989d5626fd7a69eb88578daa72652387a84f11ddd8544c0b1119fbd2e43c4972af9fb784e
+    puppeteer: lib/puppeteer/node/cli.js
+  checksum: 10/fd79fda2a45f9ee43f4594782249ac9d2113af5f38bed15542d404b875097f825245d99c0ae20f78b9b29a0ba28a40caa17357ca1377fb3c42acae9f33c1da15
   languageName: node
   linkType: hard
 
@@ -13555,13 +13533,6 @@ __metadata:
   version: 4.0.1
   resolution: "resolve-dependency-path@npm:4.0.1"
   checksum: 10/db52fc3b970c6784fa5a3695dfeccce0a9dd26d1ea7a4e83a91c30c7be11aed21d27c27c59311c5362fc1c6d2f7f5c40913304a544301c524bc18dbd98837622
-  languageName: node
-  linkType: hard
-
-"resolve-from@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "resolve-from@npm:4.0.0"
-  checksum: 10/91eb76ce83621eea7bbdd9b55121a5c1c4a39e54a9ce04a9ad4517f102f8b5131c2cf07622c738a6683991bf54f2ce178f5a42803ecbd527ddc5105f362cc9e3
   languageName: node
   linkType: hard
 
@@ -15056,10 +15027,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typed-query-selector@npm:^2.12.1":
-  version: 2.12.1
-  resolution: "typed-query-selector@npm:2.12.1"
-  checksum: 10/d0947b3f6898b7e187c23b284a0b225351530858aaefd3490ff6176df7e5625b0af067281cb980776fa102b313ae7641d2f08774c0a495445676303cfd7dfaf0
+"typed-query-selector@npm:^2.12.2":
+  version: 2.12.2
+  resolution: "typed-query-selector@npm:2.12.2"
+  checksum: 10/8fd2f2e1aed49359a90955321bd7a6acbd2011d57d865eec078ec7f40e5c5c13f1bdfbdc4484222a5df98f2c64e87d0fae0c1f35751287d487f562e7bdf825d4
   languageName: node
   linkType: hard
 
@@ -15651,44 +15622,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webdriver-bidi-protocol@npm:0.4.1":
-  version: 0.4.1
-  resolution: "webdriver-bidi-protocol@npm:0.4.1"
-  checksum: 10/3e8d6c85f5eab819c3e2b4567977295c30b7b374651eb9e00a1a05c8216a1d37c21484f7735c1c6c1b2d2dd852409c34389080e0a142c22ceda167469d479b29
+"webdriver-bidi-protocol@npm:0.4.2":
+  version: 0.4.2
+  resolution: "webdriver-bidi-protocol@npm:0.4.2"
+  checksum: 10/66b83275cf150dc2af5f296da833a045c3a4f1c0976e91a30bc4e74022d50943ebb96e85f91d82a6020349a47685eb4f892987c7e644bc38668cb94e505f39ca
   languageName: node
   linkType: hard
 
-"webdriver@npm:9.27.1":
-  version: 9.27.1
-  resolution: "webdriver@npm:9.27.1"
+"webdriver@npm:9.27.2":
+  version: 9.27.2
+  resolution: "webdriver@npm:9.27.2"
   dependencies:
     "@types/node": "npm:^20.1.0"
     "@types/ws": "npm:^8.5.3"
-    "@wdio/config": "npm:9.27.1"
+    "@wdio/config": "npm:9.27.2"
     "@wdio/logger": "npm:9.18.0"
-    "@wdio/protocols": "npm:9.27.1"
-    "@wdio/types": "npm:9.27.1"
-    "@wdio/utils": "npm:9.27.1"
+    "@wdio/protocols": "npm:9.27.2"
+    "@wdio/types": "npm:9.27.2"
+    "@wdio/utils": "npm:9.27.2"
     deepmerge-ts: "npm:^7.0.3"
     https-proxy-agent: "npm:^7.0.6"
     undici: "npm:^6.21.3"
     ws: "npm:^8.8.0"
-  checksum: 10/4b22632a048da44641ac5b1d27f8e58a28d07bf16fa86cb72af0308edc0491f1dc5bf274ae64696f54320bfa0d57cf54bd93eb6d5495d4c545624c5fb9b0481e
+  checksum: 10/7807b5ab94f4d979014e1628ed223626379b3d1a9f7d72570282f396d307b1f154fb6a469b0de425ed39061f025b71096a34a916749856f90d2ef48aacdaca87
   languageName: node
   linkType: hard
 
-"webdriverio@npm:^9.27.1":
-  version: 9.27.1
-  resolution: "webdriverio@npm:9.27.1"
+"webdriverio@npm:^9.27.2":
+  version: 9.27.2
+  resolution: "webdriverio@npm:9.27.2"
   dependencies:
     "@types/node": "npm:^20.11.30"
     "@types/sinonjs__fake-timers": "npm:^8.1.5"
-    "@wdio/config": "npm:9.27.1"
+    "@wdio/config": "npm:9.27.2"
     "@wdio/logger": "npm:9.18.0"
-    "@wdio/protocols": "npm:9.27.1"
+    "@wdio/protocols": "npm:9.27.2"
     "@wdio/repl": "npm:9.16.2"
-    "@wdio/types": "npm:9.27.1"
-    "@wdio/utils": "npm:9.27.1"
+    "@wdio/types": "npm:9.27.2"
+    "@wdio/utils": "npm:9.27.2"
     archiver: "npm:^7.0.1"
     aria-query: "npm:^5.3.0"
     cheerio: "npm:^1.0.0-rc.12"
@@ -15705,13 +15676,13 @@ __metadata:
     rgb2hex: "npm:0.2.5"
     serialize-error: "npm:^12.0.0"
     urlpattern-polyfill: "npm:^10.0.0"
-    webdriver: "npm:9.27.1"
+    webdriver: "npm:9.27.2"
   peerDependencies:
     puppeteer-core: ">=22.x || <=24.x"
   peerDependenciesMeta:
     puppeteer-core:
       optional: true
-  checksum: 10/c2f16115d2c1f80a4353266cff97257de7b7b706a643131979e17d6d2a6d588e5850c92d14f4559ed2485c519edd3464ebc2010a2b50442d96a3718de67f4b05
+  checksum: 10/586239f30a4e3635ffc4e40a2206a0cd7a76512cf2ceddfd4629861d2eb4b8260d5f2893d2d0d8c35c84bf3aac6708dd3e93400ebcbabbd137be180f5b9f493e
   languageName: node
   linkType: hard
 
@@ -15868,9 +15839,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.19.0, ws@npm:^8.20.1, ws@npm:^8.8.0":
-  version: 8.20.1
-  resolution: "ws@npm:8.20.1"
+"ws@npm:^8.20.1, ws@npm:^8.21.0, ws@npm:^8.8.0":
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -15879,7 +15850,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/8c4d2b06dc65381b6bfab1f2e584275dabd30a99a5ce058b4dc76f3d03fad1921cef3a21d8f53127d30a808cfd1864aa2fe6890a5d43359f682457315baec873
+  checksum: 10/088411956432c8f876158409d5a285cb9ad1382f593391f51d3a599bd0a5b277f876609ebd00fc3596321c4a4c9064d6fffe1ebad960e8ea7fd9ae25324f35c2
   languageName: node
   linkType: hard
 
@@ -15984,13 +15955,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yauzl@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "yauzl@npm:2.10.0"
+"yauzl@npm:3.3.1":
+  version: 3.3.1
+  resolution: "yauzl@npm:3.3.1"
   dependencies:
     buffer-crc32: "npm:~0.2.3"
-    fd-slicer: "npm:~1.1.0"
-  checksum: 10/1e4c311050dc0cf2ee3dbe8854fe0a6cde50e420b3e561a8d97042526b4cf7a0718d6c8d89e9e526a152f4a9cec55bcea9c3617264115f48bd6704cf12a04445
+    pend: "npm:~1.2.0"
+  checksum: 10/b9ecac2dca8cf0ce83d29e24ab66af50c2488f12630d0778c5190cc3ca898308986a3955fb6bbc8ee6fe21eae1691ec26068760a54d873f3930718be3bbd1ce3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,9 +1172,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cypress/request@npm:^3.0.10":
-  version: 3.0.10
-  resolution: "@cypress/request@npm:3.0.10"
+"@cypress/request@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@cypress/request@npm:4.0.0"
   dependencies:
     aws-sign2: "npm:~0.7.0"
     aws4: "npm:^1.8.0"
@@ -1193,8 +1193,7 @@ __metadata:
     safe-buffer: "npm:^5.1.2"
     tough-cookie: "npm:^5.0.0"
     tunnel-agent: "npm:^0.6.0"
-    uuid: "npm:^8.3.2"
-  checksum: 10/23c86075f5fbbd4a56403cb98dbce92b2bc33cbb0ec5779d7cb45c9ad50b5d056ff73037f11680842bb2bc4f2b79b995d91880ca7e9a893b8be650d93fad2e33
+  checksum: 10/61298f7dfe3945392ee21f6c469378109bc4ffccffbb87ef7fca6be3c84513df84c18eac6fd724714fa40755b8ad03ed2c721833009b3e7b66ba90a2bcc6eb07
   languageName: node
   linkType: hard
 
@@ -4310,7 +4309,7 @@ __metadata:
     "@siteimprove/alfa-mapper": "npm:^0.114.3"
     "@siteimprove/alfa-url": "npm:^0.114.3"
     "@siteimprove/alfa-web": "npm:^0.114.3"
-    cypress: "npm:^15.14.2"
+    cypress: "npm:^15.16.0"
   peerDependencies:
     "@siteimprove/alfa-act": ^0.114.3
     "@siteimprove/alfa-device": ^0.114.3
@@ -8087,11 +8086,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:^15.14.2":
-  version: 15.14.2
-  resolution: "cypress@npm:15.14.2"
+"cypress@npm:^15.16.0":
+  version: 15.16.0
+  resolution: "cypress@npm:15.16.0"
   dependencies:
-    "@cypress/request": "npm:^3.0.10"
+    "@cypress/request": "npm:^4.0.0"
     "@cypress/xvfb": "npm:^1.2.4"
     "@types/sinonjs__fake-timers": "npm:8.1.1"
     "@types/sizzle": "npm:^2.3.2"
@@ -8111,7 +8110,6 @@ __metadata:
     eventemitter2: "npm:6.4.7"
     execa: "npm:4.1.0"
     executable: "npm:^4.1.1"
-    extract-zip: "npm:2.0.1"
     fs-extra: "npm:^9.1.0"
     hasha: "npm:5.2.2"
     is-installed-globally: "npm:~0.4.0"
@@ -8130,10 +8128,10 @@ __metadata:
     tree-kill: "npm:1.2.2"
     tslib: "npm:1.14.1"
     untildify: "npm:^4.0.0"
-    yauzl: "npm:^2.10.0"
+    yauzl: "npm:^3.3.1"
   bin:
     cypress: bin/cypress
-  checksum: 10/1bec4c0d3313490f8c748d7173d125ea2657d37019a9e4a2cdf89feee06a1d101ce3432a555adb5dacaa1b6e2535f78b7a83bb53ade220b9cae19b2ce4927cb6
+  checksum: 10/a485b4ce2e535d5fb33cbfeb01e51a310b081f89150d56f7c49a0bd9105264f04f74add517811002c8617b640110e8d6940700aa6acc006b1fb313aee9650b78
   languageName: node
   linkType: hard
 
@@ -9154,7 +9152,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extract-zip@npm:2.0.1, extract-zip@npm:^2.0.1":
+"extract-zip@npm:^2.0.1":
   version: 2.0.1
   resolution: "extract-zip@npm:2.0.1"
   dependencies:
@@ -15310,15 +15308,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 10/9a5f7aa1d6f56dd1e8d5f2478f855f25c645e64e26e347a98e98d95781d5ed20062d6cca2eecb58ba7c84bc3910be95c0451ef4161906abaab44f9cb68ffbdd1
-  languageName: node
-  linkType: hard
-
 "v8-to-istanbul@npm:^9.0.1":
   version: 9.3.0
   resolution: "v8-to-istanbul@npm:9.3.0"
@@ -15971,6 +15960,16 @@ __metadata:
     buffer-crc32: "npm:~0.2.3"
     fd-slicer: "npm:~1.1.0"
   checksum: 10/1e4c311050dc0cf2ee3dbe8854fe0a6cde50e420b3e561a8d97042526b4cf7a0718d6c8d89e9e526a152f4a9cec55bcea9c3617264115f48bd6704cf12a04445
+  languageName: node
+  linkType: hard
+
+"yauzl@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "yauzl@npm:3.3.1"
+  dependencies:
+    buffer-crc32: "npm:~0.2.3"
+    pend: "npm:~1.2.0"
+  checksum: 10/b9ecac2dca8cf0ce83d29e24ab66af50c2488f12630d0778c5190cc3ca898308986a3955fb6bbc8ee6fe21eae1691ec26068760a54d873f3930718be3bbd1ce3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4934,7 +4934,7 @@ __metadata:
     "@siteimprove/alfa-test": "npm:^0.114.3"
     "@siteimprove/alfa-url": "npm:^0.114.3"
     "@siteimprove/alfa-web": "npm:^0.114.3"
-    playwright: "npm:^1.59.1"
+    playwright: "npm:^1.60.0"
   peerDependencies:
     "@siteimprove/alfa-device": ^0.114.3
     "@siteimprove/alfa-dom": ^0.114.3
@@ -12999,27 +12999,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.59.1":
-  version: 1.59.1
-  resolution: "playwright-core@npm:1.59.1"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
     playwright-core: cli.js
-  checksum: 10/d27857a6701587c2a9bfa26fed9a5d8c617a392299b99b187f2ddc198d012a1e296449806bc907220debea938152677e8b4d91d304ed00645f762f778de3abec
+  checksum: 10/66c0f83d627e673261c848dd6fe1f2856d5b5b6859268acb61a45c00f5bf926e596a351a9c481a3a4e82a45022c7c6b5d99ebc3906fc6876ac582ed6f7e16190
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.59.1":
-  version: 1.59.1
-  resolution: "playwright@npm:1.59.1"
+"playwright@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.59.1"
+    playwright-core: "npm:1.60.0"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10/17b2df42effa362adc6aa3192b625bd80f26b91a0c253a2375ac89ace68407b746dd87b4081629c50c58c3cb031c5b837a32fef43a3c98c60ea504e0b001e5fa
+  checksum: 10/8569770637ee35d08cca3b53a5b56c21e9236bd1ac4718456d5988fb8acd51c5b3cc2cf90748363a36199529e870a9b6c68d6fc9e19571261cd867005d6331c1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Update actions to v6.
* Update Node in CI workflow to v22/24/26.
  * There is an issue with Node 26 and the outdated `yauzl`/`extract-zip`; this somehow was backported in Node 24.16.
  * This affects browser automation packages that download and extract the browsers binaries: `cypress`, `playwright`, `puppeteer`, and `webdriverio`.
  * The problem has already been fixed upstream in `cypress`, `playwright`, and `puppeteer`, therefore this PR also update these packages (we could/should have had separate PRs for the packages updates… too late…)
  * [`webdriverio` is aware of the problem](https://github.com/webdriverio/webdriverio/issues/15265) but hasn't fixed it yet.
  * Therefore, the webdriver tests are disabled on Node 26 or 24.14; additionally, the CI workflow locks down to Node 24.14 to avoid skipping webdriver too often.
* Keep Node 24 in tooling workflows, these do not run tests (notably because we do not run coverage in the publish workflow yet), so they should not trigger the above problem.